### PR TITLE
Add scheduled reminder + KBYG emails for Lead with Ops event

### DIFF
--- a/app/api/lead-with-ops/register/route.ts
+++ b/app/api/lead-with-ops/register/route.ts
@@ -2,25 +2,18 @@ import { NextResponse } from "next/server"
 import { Resend } from "resend"
 import { checkBotId } from "botid/server"
 import { getDigitalCanvasDb } from "@/lib/firebase-admin"
+import type { DocumentReference } from "firebase-admin/firestore"
 import {
-  confirmationEmailHtml,
-  confirmationEmailText,
-  generateLeadWithOpsIcs,
-  buildListUnsubscribeHeader,
-} from "@/lib/emails/lead-with-ops"
+  EVENT_ID,
+  EVENT_NAME,
+  EVENT_DATE,
+  EVENT_COLLECTION,
+  KBYG_SCHEDULED_AT,
+  sendConfirmation,
+  sendKbyg,
+} from "@/lib/emails/lead-with-ops-resend"
 
 const isDevelopment = process.env.NODE_ENV === "development"
-
-// Event configuration — change these constants if running another cohort
-// of this same lunch format.
-const EVENT_ID = "LeadWithOpsLayerInAI-2026-06-18"
-const EVENT_NAME = "Lead with Ops. Layer in AI."
-const EVENT_DATE = "2026-06-18"
-const EVENT_COLLECTION = "event-registrations"
-
-// Sender — uses the 434 Media verified Resend domain (send.434media.com).
-// Display name "Digital Canvas" shows in the recipient's inbox.
-const EMAIL_FROM = "Digital Canvas <hello@send.434media.com>"
 
 export async function POST(request: Request) {
   try {
@@ -87,6 +80,9 @@ export async function POST(request: Request) {
     // Save to Firestore — collection: event-registrations, scoped by event id.
     // Always fail the request on Firestore errors (dev included) so the form
     // never shows a misleading success state when no data was actually saved.
+    // Captured outside the try so the email step below can stamp it with the
+    // scheduled/sent KBYG id.
+    let registrationDocRef: DocumentReference | null = null
     try {
       const db = getDigitalCanvasDb()
       const registrationRef = db.collection(EVENT_COLLECTION)
@@ -103,7 +99,7 @@ export async function POST(request: Request) {
         )
       }
 
-      await registrationRef.add({
+      registrationDocRef = await registrationRef.add({
         email: normalizedEmail,
         firstName: trimmedFirst,
         lastName: trimmedLast,
@@ -139,38 +135,77 @@ export async function POST(request: Request) {
       )
     }
 
-    // Send confirmation email — don't fail the registration if email fails.
-    // Resend is instantiated inside the try block so a missing API key (e.g.
-    // .env.local not loaded in dev) doesn't crash the route at module load.
+    // Email step — never fail the registration if email fails. Resend is
+    // instantiated inside the try block so a missing API key (e.g. .env.local
+    // not loaded in dev) doesn't crash the route at module load.
     //
-    // Confirmation includes:
-    //  - plain-text alternative (text field) — deliverability signal
-    //  - .ics attachment — universal "Add to calendar" support
-    //  - List-Unsubscribe header — RFC 2369 spam-filter signal
+    // The KBYG cutoff (KBYG_SCHEDULED_AT, Wed June 17) splits the behavior:
+    //  - BEFORE the cutoff → send the confirmation now (plain-text alternative,
+    //    .ics "Add to calendar" attachment, List-Unsubscribe header) AND schedule
+    //    the KBYG for the cutoff, so this registrant joins the day-before batch.
+    //  - AT/AFTER the cutoff → the KBYG batch has already gone out, so a late
+    //    registrant skips the now-stale confirmation and instead gets the KBYG
+    //    logistics email immediately.
+    //
+    // The save-the-date reminder is deliberately NOT sent here. A new registrant
+    // just received the confirmation, which already serves as their save-the-date;
+    // a near-duplicate reminder a day or two later would be noise. The reminder is
+    // a one-time re-warm of the registrant list, sent only via the batch scheduler
+    // (POST /api/lead-with-ops/schedule-reminder).
+    //
+    // The KBYG send is stamped onto the Firestore doc (kbygScheduled) so the batch
+    // scheduler skips them on a re-run, and the send carries a stable idempotency
+    // key so they can never be double-sent.
     try {
       if (!process.env.RESEND_API_KEY) {
-        console.warn(
-          "RESEND_API_KEY not configured — confirmation email skipped",
-        )
+        console.warn("RESEND_API_KEY not configured — registration emails skipped")
       } else {
         const resend = new Resend(process.env.RESEND_API_KEY)
-        await resend.emails.send({
-          from: EMAIL_FROM,
-          to: normalizedEmail,
-          subject: "Registration Confirmed | Lead with Ops. Layer in AI. | June 18",
-          html: confirmationEmailHtml({ firstName: trimmedFirst, fullName, email: normalizedEmail }),
-          text: confirmationEmailText({ firstName: trimmedFirst, fullName, email: normalizedEmail }),
-          attachments: [
-            {
-              filename: "lead-with-ops.ics",
-              content: Buffer.from(generateLeadWithOpsIcs()).toString("base64"),
+        const pastKbygCutoff = Date.now() >= Date.parse(KBYG_SCHEDULED_AT)
+
+        if (pastKbygCutoff) {
+          // Late registrant — KBYG immediately, no confirmation.
+          const { data, error } = await sendKbyg(resend, {
+            email: normalizedEmail,
+            firstName: trimmedFirst,
+          })
+          if (error || !data) throw new Error(error ? JSON.stringify(error) : "No data from Resend")
+          await registrationDocRef?.update({
+            kbygScheduled: {
+              id: data.id,
+              scheduledAt: new Date().toISOString(),
+              scheduledFor: "immediate-on-registration",
             },
-          ],
-          headers: {
-            "List-Unsubscribe": buildListUnsubscribeHeader(normalizedEmail),
-          },
-        })
-        console.log(`Confirmation email sent to ${normalizedEmail}`)
+          })
+          console.log(`KBYG (immediate) sent to ${normalizedEmail} — confirmation skipped (post-cutoff)`)
+        } else {
+          // Normal path — confirmation now + KBYG scheduled for the cutoff.
+          const confirmation = await sendConfirmation(resend, {
+            email: normalizedEmail,
+            firstName: trimmedFirst,
+            fullName,
+          })
+          if (confirmation.error) {
+            console.error("Confirmation email error:", confirmation.error)
+          } else {
+            console.log(`Confirmation email sent to ${normalizedEmail}`)
+          }
+
+          const { data, error } = await sendKbyg(resend, {
+            email: normalizedEmail,
+            firstName: trimmedFirst,
+            scheduledAt: KBYG_SCHEDULED_AT,
+          })
+          if (error || !data) throw new Error(error ? JSON.stringify(error) : "No data from Resend")
+          await registrationDocRef?.update({
+            kbygScheduled: {
+              id: data.id,
+              scheduledAt: KBYG_SCHEDULED_AT,
+              scheduledFor: KBYG_SCHEDULED_AT,
+            },
+          })
+          console.log(`KBYG scheduled for ${normalizedEmail} at ${KBYG_SCHEDULED_AT}`)
+        }
       }
     } catch (emailError) {
       console.error("Email send error:", emailError)

--- a/app/api/lead-with-ops/schedule-kbyg/route.ts
+++ b/app/api/lead-with-ops/schedule-kbyg/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { runScheduleBatch } from "@/lib/emails/lead-with-ops-schedule"
+
+/**
+ * Schedule the "Know Before You Go" (KBYG) email to every registrant of the
+ * Lead with Ops. Layer in AI. event using Resend's native `scheduledAt`.
+ *
+ * Resend holds each email and delivers it at the scheduled moment (default:
+ * June 17, 2026 9:00 AM CDT = 14:00 UTC, the day before the event), so the
+ * server does not need to be awake at send time. KBYG is transactional event
+ * logistics — it goes to ALL registrants regardless of the marketing opt-in.
+ *
+ * Usage:
+ *   POST /api/lead-with-ops/schedule-kbyg?secret=...
+ *   POST /api/lead-with-ops/schedule-kbyg?secret=...&dryRun=true   (list only)
+ *   POST /api/lead-with-ops/schedule-kbyg?secret=...&at=2026-06-17T14:00:00Z
+ *   POST /api/lead-with-ops/schedule-kbyg?secret=...&force=true     (reschedule)
+ *
+ * Auth reuses LEAD_WITH_OPS_TEST_SECRET. See lib/emails/lead-with-ops-schedule
+ * for the shared scheduling + idempotency implementation.
+ */
+export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const { status, body } = await runScheduleBatch({
+    template: "kbyg",
+    secret: searchParams.get("secret"),
+    dryRun: searchParams.get("dryRun") === "true",
+    force: searchParams.get("force") === "true",
+    at: searchParams.get("at"),
+  })
+  return NextResponse.json(body, { status })
+}

--- a/app/api/lead-with-ops/schedule-reminder/route.ts
+++ b/app/api/lead-with-ops/schedule-reminder/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { runScheduleBatch } from "@/lib/emails/lead-with-ops-schedule"
+
+/**
+ * Schedule the save-the-date reminder to every registrant of the Lead with Ops.
+ * Layer in AI. event using Resend's native `scheduledAt`.
+ *
+ * Resend holds each email and delivers it at the scheduled moment (default:
+ * Friday June 12, 2026 12:00 PM CDT = 17:00 UTC, ~6 days before the event), so
+ * the server does not need to be awake at send time. The reminder is a light
+ * save-the-date nudge — it goes to ALL registrants.
+ *
+ * Usage:
+ *   POST /api/lead-with-ops/schedule-reminder?secret=...
+ *   POST /api/lead-with-ops/schedule-reminder?secret=...&dryRun=true   (list only)
+ *   POST /api/lead-with-ops/schedule-reminder?secret=...&at=2026-06-12T17:00:00Z
+ *   POST /api/lead-with-ops/schedule-reminder?secret=...&force=true     (reschedule)
+ *
+ * Auth reuses LEAD_WITH_OPS_TEST_SECRET. See lib/emails/lead-with-ops-schedule
+ * for the shared scheduling + idempotency implementation.
+ */
+export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const { status, body } = await runScheduleBatch({
+    template: "reminder",
+    secret: searchParams.get("secret"),
+    dryRun: searchParams.get("dryRun") === "true",
+    force: searchParams.get("force") === "true",
+    at: searchParams.get("at"),
+  })
+  return NextResponse.json(body, { status })
+}

--- a/app/api/lead-with-ops/send-test/route.ts
+++ b/app/api/lead-with-ops/send-test/route.ts
@@ -3,8 +3,10 @@ import { Resend } from "resend"
 import {
   confirmationEmailHtml,
   kbygEmailHtml,
+  reminderEmailHtml,
   confirmationEmailText,
   kbygEmailText,
+  reminderEmailText,
   generateLeadWithOpsIcs,
   buildListUnsubscribeHeader,
 } from "@/lib/emails/lead-with-ops"
@@ -42,7 +44,7 @@ const TEST_RECIPIENTS = [
   { email: "jesse@434media.com", firstName: "Jesse", lastName: "Hernandez" },
 ]
 
-type TemplateKey = "confirmation" | "kbyg"
+type TemplateKey = "confirmation" | "kbyg" | "reminder"
 
 export async function POST(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -56,9 +58,9 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 
-  if (!template || !["confirmation", "kbyg"].includes(template)) {
+  if (!template || !["confirmation", "kbyg", "reminder"].includes(template)) {
     return NextResponse.json(
-      { error: "Missing or invalid `template` query param. Use: confirmation | kbyg. (Invite broadcasts are sent from the 434 Media admin app.)" },
+      { error: "Missing or invalid `template` query param. Use: confirmation | kbyg | reminder. (Invite broadcasts are sent from the 434 Media admin app.)" },
       { status: 400 },
     )
   }
@@ -97,10 +99,13 @@ export async function POST(request: Request) {
   //    to any calendar app (Apple Mail / Outlook recognize attachments;
   //    Google + Outlook web also have deep links in the email body).
   //  - kbyg → campus map PDF, fetched by Resend from Firebase Storage.
+  //  - reminder → no attachment (re-shares calendar deep links in the body).
   type Attachment = { filename: string; path?: string; content?: string }
   let attachments: Attachment[] | undefined
   if (template === "kbyg") {
     attachments = [{ filename: CAMPUS_MAP_FILENAME, path: CAMPUS_MAP_URL }]
+  } else if (template === "reminder") {
+    attachments = undefined
   } else {
     attachments = [
       {
@@ -124,6 +129,10 @@ export async function POST(request: Request) {
       subject = "Registration Confirmed | Lead with Ops. Layer in AI. | June 18"
       html = confirmationEmailHtml({ firstName: recipient.firstName, fullName, email: recipient.email })
       text = confirmationEmailText({ firstName: recipient.firstName, fullName, email: recipient.email })
+    } else if (template === "reminder") {
+      subject = "Save the date: Lead with Ops. Layer in AI. is June 18"
+      html = reminderEmailHtml({ firstName: recipient.firstName, email: recipient.email })
+      text = reminderEmailText({ firstName: recipient.firstName, email: recipient.email })
     } else {
       subject = "Tomorrow: What to know before Lead with Ops. Layer in AI."
       html = kbygEmailHtml({ firstName: recipient.firstName, email: recipient.email })

--- a/lib/emails/lead-with-ops-resend.ts
+++ b/lib/emails/lead-with-ops-resend.ts
@@ -1,0 +1,155 @@
+/**
+ * Resend send helpers + shared constants for the Lead with Ops. Layer in AI.
+ * event (June 18, 2026). This is the single source of truth for:
+ *   - the event id / Firestore collection
+ *   - the verified sender + subjects
+ *   - the KBYG delivery cutoff (`KBYG_SCHEDULED_AT`)
+ *   - the actual Resend send calls (KBYG + confirmation)
+ *
+ * Both the batch scheduler (app/api/lead-with-ops/schedule-kbyg) and the
+ * per-registration flow (app/api/lead-with-ops/register) import from here so
+ * they always agree on the cutoff time and the idempotency key — which is what
+ * prevents a registrant from being double-sent the KBYG email.
+ */
+import type { Resend } from "resend"
+import {
+  kbygEmailHtml,
+  kbygEmailText,
+  confirmationEmailHtml,
+  confirmationEmailText,
+  reminderEmailHtml,
+  reminderEmailText,
+  generateLeadWithOpsIcs,
+  buildListUnsubscribeHeader,
+} from "@/lib/emails/lead-with-ops"
+
+export const EVENT_ID = "LeadWithOpsLayerInAI-2026-06-18"
+export const EVENT_NAME = "Lead with Ops. Layer in AI."
+export const EVENT_DATE = "2026-06-18"
+export const EVENT_COLLECTION = "event-registrations"
+
+// Sender — 434 Media verified Resend domain (send.434media.com).
+export const EMAIL_FROM = "Digital Canvas <hello@send.434media.com>"
+
+export const KBYG_SUBJECT = "Tomorrow: What to know before Lead with Ops. Layer in AI."
+export const CONFIRMATION_SUBJECT =
+  "Registration Confirmed | Lead with Ops. Layer in AI. | June 18"
+export const REMINDER_SUBJECT = "Save the date: Lead with Ops. Layer in AI. is June 18"
+
+/**
+ * KBYG delivery cutoff — June 17, 2026 9:00 AM CDT (UTC-5) = 14:00 UTC, the day
+ * before the event. The batch scheduler hands every existing registrant a KBYG
+ * email scheduled for this instant. It is also the pivot for the registration
+ * flow:
+ *   - register BEFORE this time → confirmation now + KBYG scheduled for this time
+ *   - register AT/AFTER this time → KBYG sent immediately, confirmation skipped
+ */
+export const KBYG_SCHEDULED_AT = "2026-06-17T14:00:00Z"
+
+/**
+ * Save-the-date reminder delivery time — Friday June 12, 2026 12:00 PM CDT
+ * (UTC-5) = 17:00 UTC, roughly six days before the event. Like the KBYG cutoff,
+ * this is the pivot for the registration flow: registrations before this time
+ * are folded into the reminder batch; registrations after it skip the reminder
+ * (it would already have gone out).
+ */
+export const REMINDER_SCHEDULED_AT = "2026-06-12T17:00:00Z"
+
+// Campus map PDF, fetched by Resend from Firebase Storage at send time and
+// attached to every KBYG email.
+export const CAMPUS_MAP_URL =
+  "https://firebasestorage.googleapis.com/v0/b/groovy-ego-462522-v2.firebasestorage.app/o/digitalcanvas%2FVTX-Campus-Map-2025.pdf?alt=media"
+export const CAMPUS_MAP_FILENAME = "VelocityTX-Campus-Map.pdf"
+
+/**
+ * Stable per-recipient idempotency key for the KBYG send. Reused by both the
+ * batch scheduler and the registration flow so that even if both attempt a send
+ * for the same person, Resend collapses them into one email (within its
+ * idempotency window) instead of delivering twice.
+ */
+export function kbygIdempotencyKey(email: string): string {
+  return `kbyg-${EVENT_ID}-${email}`
+}
+
+/** Stable per-recipient idempotency key for the reminder send. */
+export function reminderIdempotencyKey(email: string): string {
+  return `reminder-${EVENT_ID}-${email}`
+}
+
+/**
+ * Send (or schedule) the KBYG email to one recipient.
+ * Pass `scheduledAt` (ISO 8601) to schedule for later; omit it to send now.
+ * Returns Resend's `{ data, error }` result — callers decide how to handle it.
+ */
+export function sendKbyg(
+  resend: Resend,
+  opts: { email: string; firstName: string; scheduledAt?: string },
+) {
+  return resend.emails.send(
+    {
+      from: EMAIL_FROM,
+      to: opts.email,
+      subject: KBYG_SUBJECT,
+      html: kbygEmailHtml({ firstName: opts.firstName, email: opts.email }),
+      text: kbygEmailText({ firstName: opts.firstName, email: opts.email }),
+      attachments: [{ filename: CAMPUS_MAP_FILENAME, path: CAMPUS_MAP_URL }],
+      headers: { "List-Unsubscribe": buildListUnsubscribeHeader(opts.email) },
+      ...(opts.scheduledAt ? { scheduledAt: opts.scheduledAt } : {}),
+    },
+    { idempotencyKey: kbygIdempotencyKey(opts.email) },
+  )
+}
+
+/**
+ * Send (or schedule) the save-the-date reminder to one recipient.
+ * Pass `scheduledAt` (ISO 8601) to schedule for later; omit it to send now.
+ * No attachment — the reminder re-shares the calendar deep links in its body.
+ */
+export function sendReminder(
+  resend: Resend,
+  opts: { email: string; firstName: string; scheduledAt?: string },
+) {
+  return resend.emails.send(
+    {
+      from: EMAIL_FROM,
+      to: opts.email,
+      subject: REMINDER_SUBJECT,
+      html: reminderEmailHtml({ firstName: opts.firstName, email: opts.email }),
+      text: reminderEmailText({ firstName: opts.firstName, email: opts.email }),
+      headers: { "List-Unsubscribe": buildListUnsubscribeHeader(opts.email) },
+      ...(opts.scheduledAt ? { scheduledAt: opts.scheduledAt } : {}),
+    },
+    { idempotencyKey: reminderIdempotencyKey(opts.email) },
+  )
+}
+
+/**
+ * Send the registration-confirmation email (with .ics calendar attachment).
+ */
+export function sendConfirmation(
+  resend: Resend,
+  opts: { email: string; firstName: string; fullName: string },
+) {
+  return resend.emails.send({
+    from: EMAIL_FROM,
+    to: opts.email,
+    subject: CONFIRMATION_SUBJECT,
+    html: confirmationEmailHtml({
+      firstName: opts.firstName,
+      fullName: opts.fullName,
+      email: opts.email,
+    }),
+    text: confirmationEmailText({
+      firstName: opts.firstName,
+      fullName: opts.fullName,
+      email: opts.email,
+    }),
+    attachments: [
+      {
+        filename: "lead-with-ops.ics",
+        content: Buffer.from(generateLeadWithOpsIcs()).toString("base64"),
+      },
+    ],
+    headers: { "List-Unsubscribe": buildListUnsubscribeHeader(opts.email) },
+  })
+}

--- a/lib/emails/lead-with-ops-schedule.ts
+++ b/lib/emails/lead-with-ops-schedule.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared batch scheduler for the Lead with Ops. Layer in AI. event emails.
+ *
+ * Both the reminder (save-the-date, ~6 days out) and the KBYG (know-before-you-go,
+ * day before) go out the same way: hand every registrant a Resend email with a
+ * future `scheduledAt`, so Resend holds and delivers them — no cron, no server
+ * needing to be awake at send time. This module is the single implementation;
+ * the per-template routes are thin wrappers that call runScheduleBatch().
+ *
+ * Idempotency:
+ *  - Each registration doc is stamped (`reminderScheduled` / `kbygScheduled`)
+ *    once scheduled. Re-running skips stamped recipients unless force=true.
+ *  - Each Resend send carries a stable idempotency key so even a forced retry
+ *    inside Resend's window won't duplicate the send.
+ *  - The stored Resend email id can be passed to Resend's cancel endpoint to
+ *    unschedule a recipient before the send time.
+ */
+import { Resend } from "resend"
+import { getDigitalCanvasDb } from "@/lib/firebase-admin"
+import {
+  EVENT_ID,
+  EVENT_COLLECTION,
+  KBYG_SCHEDULED_AT,
+  REMINDER_SCHEDULED_AT,
+  sendKbyg,
+  sendReminder,
+} from "@/lib/emails/lead-with-ops-resend"
+
+export type ScheduleTemplate = "kbyg" | "reminder"
+
+type Stamp = { id: string; scheduledAt: string; scheduledFor: string }
+
+const TEMPLATES = {
+  kbyg: {
+    label: "KBYG",
+    stampField: "kbygScheduled" as const,
+    defaultAt: KBYG_SCHEDULED_AT,
+    send: sendKbyg,
+  },
+  reminder: {
+    label: "reminder",
+    stampField: "reminderScheduled" as const,
+    defaultAt: REMINDER_SCHEDULED_AT,
+    send: sendReminder,
+  },
+} as const
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export type ScheduleBatchResult = { status: number; body: Record<string, unknown> }
+
+/**
+ * Schedule one template to every registrant. Returns a status + JSON body for
+ * the calling route to relay verbatim.
+ */
+export async function runScheduleBatch(opts: {
+  template: ScheduleTemplate
+  secret: string | null
+  dryRun: boolean
+  force: boolean
+  at: string | null
+}): Promise<ScheduleBatchResult> {
+  const cfg = TEMPLATES[opts.template]
+
+  // Auth — same gate as the test-send endpoint, never an open relay.
+  if (!opts.secret || opts.secret !== process.env.LEAD_WITH_OPS_TEST_SECRET) {
+    return { status: 401, body: { error: "Unauthorized" } }
+  }
+
+  // Validate the scheduled time — parseable ISO 8601, in the future.
+  const scheduledAt = opts.at || cfg.defaultAt
+  const scheduledMs = Date.parse(scheduledAt)
+  if (Number.isNaN(scheduledMs)) {
+    return {
+      status: 400,
+      body: { error: `Invalid \`at\` value: "${scheduledAt}". Use ISO 8601, e.g. ${cfg.defaultAt}` },
+    }
+  }
+  if (scheduledMs <= Date.now()) {
+    return { status: 400, body: { error: `Scheduled time ${scheduledAt} is in the past. Pick a future time.` } }
+  }
+
+  if (!process.env.RESEND_API_KEY) {
+    return { status: 503, body: { error: "RESEND_API_KEY is not configured on the server" } }
+  }
+
+  // Load every registrant for this event.
+  type RegistrationDoc = {
+    email?: string
+    firstName?: string
+    [key: string]: unknown
+  }
+  let docs: { id: string; data: RegistrationDoc }[]
+  try {
+    const db = getDigitalCanvasDb()
+    const snapshot = await db.collection(EVENT_COLLECTION).where("event", "==", EVENT_ID).get()
+    docs = snapshot.docs.map((d) => ({ id: d.id, data: d.data() as RegistrationDoc }))
+  } catch (firestoreError) {
+    const message = firestoreError instanceof Error ? firestoreError.message : String(firestoreError)
+    console.error("Firestore error loading registrants:", message)
+    return { status: 503, body: { error: `Could not load registrants: ${message}` } }
+  }
+
+  // Partition: skippable (no email / already scheduled) vs. to-schedule.
+  const toSchedule: { id: string; email: string; firstName: string }[] = []
+  const skipped: { recipient: string; reason: string }[] = []
+
+  for (const { id, data } of docs) {
+    const email = data.email?.toLowerCase().trim()
+    if (!email) {
+      skipped.push({ recipient: `(doc ${id})`, reason: "missing email" })
+      continue
+    }
+    const existing = data[cfg.stampField] as Stamp | undefined
+    if (existing && !opts.force) {
+      skipped.push({ recipient: email, reason: `already scheduled (${existing.scheduledFor})` })
+      continue
+    }
+    toSchedule.push({ id, email, firstName: data.firstName?.trim() || "Friend" })
+  }
+
+  if (opts.dryRun) {
+    return {
+      status: 200,
+      body: {
+        dryRun: true,
+        template: opts.template,
+        event: EVENT_ID,
+        scheduledAt,
+        totalRegistrants: docs.length,
+        wouldSchedule: toSchedule.map((r) => r.email),
+        skipped,
+      },
+    }
+  }
+
+  const resend = new Resend(process.env.RESEND_API_KEY)
+  const db = getDigitalCanvasDb()
+
+  const results: { recipient: string; status: "scheduled" | "failed"; id?: string; error?: string }[] = []
+
+  for (const { id, email, firstName } of toSchedule) {
+    try {
+      const { data: sendData, error: sendError } = await cfg.send(resend, { email, firstName, scheduledAt })
+
+      if (sendError || !sendData) {
+        throw new Error(sendError ? JSON.stringify(sendError) : "No data returned from Resend")
+      }
+
+      // Stamp the doc so re-runs skip it and the Resend id is recoverable for
+      // cancellation. Non-fatal if this write fails — the email is scheduled.
+      const stamp: Stamp = { id: sendData.id, scheduledAt, scheduledFor: scheduledAt }
+      try {
+        await db.collection(EVENT_COLLECTION).doc(id).update({ [cfg.stampField]: stamp })
+      } catch (writeError) {
+        console.error(`Scheduled ${cfg.label} for ${email} but failed to stamp doc ${id}:`, writeError)
+      }
+
+      results.push({ recipient: email, status: "scheduled", id: sendData.id })
+    } catch (err) {
+      console.error(`Failed to schedule ${cfg.label} for ${email}:`, err)
+      results.push({ recipient: email, status: "failed", error: String(err) })
+    }
+
+    // Gentle throttle to stay under Resend's per-second send rate limit.
+    await sleep(120)
+  }
+
+  const failed = results.filter((r) => r.status === "failed")
+  return {
+    status: failed.length > 0 ? 207 : 200,
+    body: {
+      template: opts.template,
+      event: EVENT_ID,
+      scheduledAt,
+      totalRegistrants: docs.length,
+      scheduledCount: results.filter((r) => r.status === "scheduled").length,
+      failedCount: failed.length,
+      skipped,
+      results,
+    },
+  }
+}

--- a/lib/emails/lead-with-ops.ts
+++ b/lib/emails/lead-with-ops.ts
@@ -653,6 +653,97 @@ export function kbygEmailHtml(opts: KbygOpts): string {
 }
 
 /* ----------------------------------------------------------------------
+ * Template 4 — Save-the-date reminder.
+ * A light mid-cycle nudge (sent ~6 days before, the Friday prior) that keeps
+ * the event on the recipient's radar without the day-before logistics weight.
+ * No attachment — re-shares the calendar deep links instead.
+ * -------------------------------------------------------------------- */
+
+export function reminderEmailHtml(opts: KbygOpts): string {
+  const body = `
+<!-- Eyebrow + title -->
+<tr>
+  <td style="padding: 32px 32px 0 32px;">
+    <p style="margin: 0 0 14px 0; font-family: ${PIXEL_STACK}; font-size: 11px; letter-spacing: 3px; text-transform: uppercase; color: ${C.emerald}; font-weight: 700;">
+      Save the Date · Less Than a Week Away
+    </p>
+    <h1 style="margin: 0; font-family: ${PIXEL_STACK}; font-size: 32px; font-weight: 800; line-height: 1.1; text-transform: uppercase; letter-spacing: 0.5px; color: ${C.navy};">
+      Lead with Ops.<br />
+      <span style="color: ${C.gray};">Layer in AI.</span>
+    </h1>
+  </td>
+</tr>
+
+<!-- Greeting + lede -->
+<tr>
+  <td style="padding: 28px 32px 0 32px;">
+    <p style="margin: 0 0 18px 0; font-size: 16px; line-height: 1.7; color: ${C.navy};">
+      Hi ${escapeHtml(opts.firstName)},
+    </p>
+    <p style="margin: 0 0 18px 0; font-size: 16px; line-height: 1.7; color: ${C.gray};">
+      Just a quick note to keep this on your radar &mdash; your seat for <strong style="color: ${C.navy};">Lead with Ops. Layer in AI.</strong> with <strong style="color: ${C.navy};">Adam Carroll, Founder of Carroll Strategy &amp; Operations</strong>, is reserved, and the executive working lunch is now less than a week away.
+    </p>
+    <p style="margin: 0 0 24px 0; font-size: 15px; line-height: 1.7; color: ${C.emerald}; font-weight: 700;">
+      Thursday, June 18 &mdash; we&rsquo;re looking forward to hosting you.
+    </p>
+  </td>
+</tr>
+
+<!-- Event details -->
+<tr>
+  <td style="padding: 0 32px 24px 32px;">
+    ${EVENT_DETAILS_BLOCK}
+  </td>
+</tr>
+
+<!-- Add to calendar — re-share Google + Outlook deep links -->
+<tr>
+  <td style="padding: 0 32px 28px 32px;">
+    <p style="margin: 0 0 12px 0; font-family: ${PIXEL_STACK}; font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: ${C.gray}; font-weight: 700;">
+      Not on your calendar yet?
+    </p>
+    <table role="presentation" style="border-collapse: collapse;">
+      <tr>
+        <td style="padding-right: 8px;">
+          <a href="${googleCalendarUrl()}" target="_blank" style="display: inline-block; padding: 10px 18px; border: 1px solid ${C.border}; color: ${C.navy}; text-decoration: none; font-family: ${PIXEL_STACK}; font-size: 11px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase;">
+            Google
+          </a>
+        </td>
+        <td style="padding-right: 8px;">
+          <a href="${outlookCalendarUrl()}" target="_blank" style="display: inline-block; padding: 10px 18px; border: 1px solid ${C.border}; color: ${C.navy}; text-decoration: none; font-family: ${PIXEL_STACK}; font-size: 11px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase;">
+            Outlook
+          </a>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+
+<!-- Closing -->
+<tr>
+  <td style="padding: 0 32px 24px 32px;">
+    <p style="margin: 0 0 18px 0; font-size: 14px; line-height: 1.7; color: ${C.gray};">
+      We&rsquo;ll follow up the day before with a short &ldquo;know before you go&rdquo; note &mdash; parking, arrival time, and a campus map. Nothing else needed from you until then.
+    </p>
+    <p style="margin: 0 0 20px 0; font-size: 14px; line-height: 1.7; color: ${C.gray};">
+      If your plans change, just reply to this email so we can offer your seat to another participant.
+    </p>
+    <p style="margin: 0; font-size: 15px; color: ${C.navy}; font-weight: 600;">
+      See you on June 18.
+    </p>
+  </td>
+</tr>
+`.trim()
+
+  return shell({
+    title: "Save the date: Lead with Ops. Layer in AI. is June 18",
+    previewText: "Your seat is reserved — the executive working lunch with Adam Carroll is less than a week away at VelocityTX CRC.",
+    body,
+    unsubscribeUrl: buildUnsubscribeUrl(opts.email),
+  })
+}
+
+/* ----------------------------------------------------------------------
  * Plain-text alternatives — sent as the `text` field alongside `html`.
  *
  * Including a text/plain part is a strong deliverability signal — providers
@@ -743,6 +834,43 @@ This is an off-the-record, peer-level conversation. No product demos, no pitch d
 If your plans change, please reply to this email so we can offer the seat to another attendee.
 
 See you tomorrow.
+
+—
+Presented by Digital Canvas · 434 Media
+Questions? VIP@434MEDIA.COM
+
+You're receiving this because you opted in to the 434 Media network.
+Unsubscribe: ${buildUnsubscribeUrl(opts.email)}`
+}
+
+export function reminderEmailText(opts: KbygOpts): string {
+  return `SAVE THE DATE · LESS THAN A WEEK AWAY
+
+Lead with Ops. Layer in AI.
+
+Hi ${opts.firstName},
+
+Just a quick note to keep this on your radar — your seat for Lead with Ops. Layer in AI. with Adam Carroll, Founder of Carroll Strategy & Operations, is reserved, and the executive working lunch is now less than a week away.
+
+Thursday, June 18 — we're looking forward to hosting you.
+
+EVENT DETAILS
+-------------
+Date:     June 18, 2026
+Time:     11:30 AM – 1:00 PM
+Location: VelocityTX CRC, 1305 E. Houston St., San Antonio, TX 78205
+Lunch:    Provided
+
+NOT ON YOUR CALENDAR YET?
+-------------------------
+Google Calendar: ${googleCalendarUrl()}
+Outlook:         ${outlookCalendarUrl()}
+
+We'll follow up the day before with a short "know before you go" note — parking, arrival time, and a campus map. Nothing else needed from you until then.
+
+If your plans change, just reply to this email so we can offer your seat to another participant.
+
+See you on June 18.
 
 —
 Presented by Digital Canvas · 434 Media


### PR DESCRIPTION
## Summary
Wires up Resend `scheduledAt` sends for the **Lead with Ops. Layer in AI.** event (June 18, 2026), so the day-before KBYG and a save-the-date reminder are handed to Resend in advance and delivered without a cron job.

## What's included
- **Reminder template** (`lib/emails/lead-with-ops.ts`) — `reminderEmailHtml` / `reminderEmailText`, a light save-the-date nudge matching the Carroll design system (emerald accent, no attachment, re-shares calendar deep links).
- **Shared helpers**
  - `lead-with-ops-resend.ts` — single source of truth for event constants, sender, subjects, the two cutoffs (`REMINDER_SCHEDULED_AT` Jun 12, `KBYG_SCHEDULED_AT` Jun 17), and the `sendKbyg` / `sendReminder` / `sendConfirmation` calls with stable per-recipient idempotency keys (no double-sends).
  - `lead-with-ops-schedule.ts` — one batch scheduler (`runScheduleBatch`) parameterized by template; loads registrants, skips already-stamped docs, schedules via Resend, stamps `reminderScheduled` / `kbygScheduled` back. Supports `dryRun` / `force` / `at`.
- **Routes**
  - `schedule-kbyg` + `schedule-reminder` — thin wrappers over the shared scheduler.
  - `register` — time-aware: before the KBYG cutoff → confirmation now + KBYG scheduled; at/after the cutoff → KBYG immediately, confirmation skipped. Reminder is intentionally **not** sent here (a fresh registrant's confirmation already covers save-the-date).
  - `send-test` — adds the reminder template for preview/QA.

## Email timeline
| When | Email |
|------|-------|
| at registration (before Jun 17) | Confirmation (with `.ics`) |
| Fri Jun 12, 12 PM CDT | Reminder (batch, 15 registrants) |
| Wed Jun 17, 9 AM CDT | KBYG (batch, 15 registrants) |
| register after Jun 17 | KBYG immediately, no confirmation |

## Verification
- TypeScript clean (only a pre-existing unrelated `three` types error).
- Both batches already scheduled live and verified in Resend's `scheduled` state (15 reminders for Jun 12, 15 KBYG for Jun 17).
- Registration flow tested end-to-end (pre- and post-cutoff paths) with disposable addresses, then cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)