### PR TITLE
Add post-event feedback form for Lead with Ops event

### DIFF
--- a/app/api/lead-with-ops/feedback/route.ts
+++ b/app/api/lead-with-ops/feedback/route.ts
@@ -1,0 +1,168 @@
+import { NextResponse } from "next/server"
+import { getDigitalCanvasDb } from "@/lib/firebase-admin"
+import { EVENT_ID, EVENT_NAME, EVENT_DATE } from "@/lib/emails/lead-with-ops-resend"
+import {
+  FEEDBACK_COLLECTION,
+  SESSION_VALUE_MIN,
+  SESSION_VALUE_MAX,
+  SESSION_VALUE_LOW_LABEL,
+  SESSION_VALUE_HIGH_LABEL,
+  TALK_FURTHER_OPTIONS,
+  ROLE_OPTIONS,
+  INDUSTRY_OPTIONS,
+  HEARD_ABOUT_OPTIONS,
+  OTHER_OPTION,
+} from "@/lib/lead-with-ops-feedback"
+
+const isDevelopment = process.env.NODE_ENV === "development"
+
+/**
+ * Post-event feedback intake for the Lead with Ops. Layer in AI. lunch.
+ * Mirrors the registration route's validation + single write into the
+ * `digitalcanvas` Firestore database, but sends no email and does not dedupe
+ * (an attendee may resubmit; each submission is its own row).
+ *
+ * Unlike registration, this endpoint is intentionally NOT behind Vercel BotID.
+ * Feedback is a low-value target for bots, and the client-side BotID challenge
+ * can silently hang for legitimate attendees (privacy extensions / ad blockers
+ * return an empty body for the challenge script, so the wrapped fetch never
+ * resolves). For a form we want every attendee to complete, reliable delivery
+ * beats bot protection here. Registration keeps BotID.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const {
+      email,
+      name,
+      company,
+      sessionValue,
+      mostUseful,
+      talkFurther,
+      role,
+      industry,
+      industryOther,
+      biggestQuestion,
+      heardAbout,
+    }: {
+      email?: string
+      name?: string
+      company?: string
+      sessionValue?: number | string
+      mostUseful?: string
+      talkFurther?: string
+      role?: string
+      industry?: string
+      industryOther?: string
+      biggestQuestion?: string
+      heardAbout?: string
+    } = body
+
+    // --- Required free-text + identity fields -------------------------------
+    const requiredText: Record<string, unknown> = { email, name, company, mostUseful, biggestQuestion }
+    for (const [field, value] of Object.entries(requiredText)) {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        return NextResponse.json({ error: `${field} is required` }, { status: 400 })
+      }
+    }
+
+    const normalizedEmail = (email as string).toLowerCase().trim()
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(normalizedEmail)) {
+      return NextResponse.json({ error: "Invalid email format" }, { status: 400 })
+    }
+
+    // --- Q2: session value (1–5) -------------------------------------------
+    const valueNumeric = typeof sessionValue === "string" ? Number.parseInt(sessionValue, 10) : sessionValue
+    if (
+      typeof valueNumeric !== "number" ||
+      Number.isNaN(valueNumeric) ||
+      valueNumeric < SESSION_VALUE_MIN ||
+      valueNumeric > SESSION_VALUE_MAX
+    ) {
+      return NextResponse.json(
+        { error: `sessionValue must be a number from ${SESSION_VALUE_MIN} to ${SESSION_VALUE_MAX}` },
+        { status: 400 },
+      )
+    }
+
+    // --- Single-choice enums ------------------------------------------------
+    const enumChecks: { field: string; value: unknown; allowed: readonly string[] }[] = [
+      { field: "talkFurther", value: talkFurther, allowed: TALK_FURTHER_OPTIONS },
+      { field: "role", value: role, allowed: ROLE_OPTIONS },
+      { field: "industry", value: industry, allowed: INDUSTRY_OPTIONS },
+      { field: "heardAbout", value: heardAbout, allowed: HEARD_ABOUT_OPTIONS },
+    ]
+    for (const { field, value, allowed } of enumChecks) {
+      if (typeof value !== "string" || !allowed.includes(value)) {
+        return NextResponse.json({ error: `${field} must be one of the provided options` }, { status: 400 })
+      }
+    }
+
+    // --- Q8: "Other" industry requires a short answer ----------------------
+    const trimmedIndustryOther =
+      typeof industryOther === "string" ? industryOther.trim() : ""
+    if (industry === OTHER_OPTION && trimmedIndustryOther.length === 0) {
+      return NextResponse.json(
+        { error: "Please specify your industry" },
+        { status: 400 },
+      )
+    }
+
+    // --- Persist ------------------------------------------------------------
+    // Always fail the request on Firestore errors (dev included) so the form
+    // never shows a misleading success state when no data was actually saved.
+    try {
+      const db = getDigitalCanvasDb()
+      await db.collection(FEEDBACK_COLLECTION).add({
+        email: normalizedEmail,
+        name: (name as string).trim(),
+        company: (company as string).trim(),
+        sessionValue: valueNumeric,
+        sessionValueScale: `${SESSION_VALUE_MIN} (${SESSION_VALUE_LOW_LABEL}) – ${SESSION_VALUE_MAX} (${SESSION_VALUE_HIGH_LABEL})`,
+        mostUseful: (mostUseful as string).trim(),
+        talkFurther,
+        role,
+        industry,
+        ...(industry === OTHER_OPTION ? { industryOther: trimmedIndustryOther } : {}),
+        biggestQuestion: (biggestQuestion as string).trim(),
+        heardAbout,
+        event: EVENT_ID,
+        eventName: EVENT_NAME,
+        eventDate: EVENT_DATE,
+        submittedAt: new Date().toISOString(),
+        source: "web-digitalcanvas",
+        tags: [
+          "event-feedback",
+          "lead-with-ops-2026-06-18",
+          ...(talkFurther === TALK_FURTHER_OPTIONS[0] ? ["feedback-wants-call"] : []),
+        ],
+        pageUrl: request.headers.get("referer") || null,
+      })
+
+      console.log(`Lead with Ops feedback saved for ${normalizedEmail}`)
+    } catch (firestoreError) {
+      const message = firestoreError instanceof Error ? firestoreError.message : String(firestoreError)
+      console.error("Firestore error:", message)
+      return NextResponse.json(
+        {
+          error: isDevelopment
+            ? `Feedback could not be saved: ${message}`
+            : "Feedback service temporarily unavailable. Please try again or contact us directly.",
+        },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json(
+      { message: "Feedback received", data: { name: (name as string).trim() } },
+      { status: 200 },
+    )
+  } catch (error) {
+    console.error("Feedback error:", error)
+    return NextResponse.json(
+      { error: "An unexpected error occurred. Please try again." },
+      { status: 500 },
+    )
+  }
+}

--- a/app/workshops/lead-with-ops/feedback/layout.tsx
+++ b/app/workshops/lead-with-ops/feedback/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next"
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.digitalcanvas.community"
+
+export const metadata: Metadata = {
+  title: "Lunch and Learn Feedback | Lead with Ops. Layer in AI.",
+  description:
+    "Ninety seconds of feedback on the Lead with Ops. Layer in AI. executive working lunch with Adam Carroll. It shapes the next session — and tells us who'd like to keep the conversation going.",
+  alternates: {
+    canonical: "/workshops/lead-with-ops/feedback",
+  },
+  // Post-event intake form — not meant to be indexed or shared as a social card.
+  robots: {
+    index: false,
+    follow: false,
+  },
+  openGraph: {
+    title: "Lunch and Learn Feedback | Lead with Ops. Layer in AI.",
+    description:
+      "Ninety seconds of feedback shapes the next session. Lead with Ops. Layer in AI. — Digital Canvas · 434 Media.",
+    url: `${siteUrl}/workshops/lead-with-ops/feedback`,
+    siteName: "Digital Canvas",
+    locale: "en_US",
+    type: "website",
+  },
+}
+
+export default function LeadWithOpsFeedbackLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/app/workshops/lead-with-ops/feedback/page.tsx
+++ b/app/workshops/lead-with-ops/feedback/page.tsx
@@ -1,0 +1,399 @@
+"use client"
+
+import { useState, type FormEvent } from "react"
+import { motion } from "motion/react"
+import {
+  SESSION_VALUE_MIN,
+  SESSION_VALUE_MAX,
+  SESSION_VALUE_LOW_LABEL,
+  SESSION_VALUE_HIGH_LABEL,
+  TALK_FURTHER_OPTIONS,
+  ROLE_OPTIONS,
+  INDUSTRY_OPTIONS,
+  HEARD_ABOUT_OPTIONS,
+  OTHER_OPTION,
+} from "@/lib/lead-with-ops-feedback"
+
+// Carroll Strategy & Operations color system — matches the event page.
+const EMERALD = "#1AAD9B" // positive accent: selection, structural bullets
+const CORAL = "#FF5757" // sparingly: CTA, required markers, errors
+
+const SESSION_SCALE = Array.from(
+  { length: SESSION_VALUE_MAX - SESSION_VALUE_MIN + 1 },
+  (_, i) => SESSION_VALUE_MIN + i,
+)
+
+type FormStatus = "idle" | "submitting" | "success" | "error"
+
+// Shared field-label styling (pixel font, uppercase, tracked) with a required mark.
+function FieldLabel({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-[#6F7883] font-bold mb-2 block"
+    >
+      {children} <span style={{ color: CORAL }}>*</span>
+    </label>
+  )
+}
+
+const inputClass =
+  "w-full bg-white border border-[#E1E4EA] text-[#041C32] text-sm px-3.5 py-3 focus:outline-none focus:border-[#041C32] transition-colors placeholder:text-[#6F7883]/60"
+
+// One styled single-choice list (radio group) with emerald selection accent.
+function ChoiceGroup({
+  legend,
+  options,
+  value,
+  onChange,
+}: {
+  legend: string
+  options: readonly string[]
+  value: string | null
+  onChange: (v: string) => void
+}) {
+  return (
+    <fieldset>
+      <legend className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-[#6F7883] font-bold mb-2 block">
+        {legend} <span style={{ color: CORAL }}>*</span>
+      </legend>
+      <div className="space-y-2" role="radiogroup" aria-label={legend}>
+        {options.map((opt) => {
+          const isSelected = value === opt
+          return (
+            <button
+              key={opt}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              onClick={() => onChange(opt)}
+              className={`w-full text-left text-sm px-3.5 py-3 border-l-2 border transition-colors ${
+                isSelected
+                  ? "border-transparent text-[#041C32] font-medium"
+                  : "border-[#E1E4EA] bg-white text-[#041C32]/80 hover:border-[#041C32]/40"
+              }`}
+              style={isSelected ? { backgroundColor: `${EMERALD}1A`, borderLeftColor: EMERALD } : undefined}
+            >
+              {opt}
+            </button>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}
+
+export default function LeadWithOpsFeedbackPage() {
+  const [status, setStatus] = useState<FormStatus>("idle")
+  const [errorMsg, setErrorMsg] = useState("")
+  const [thanksName, setThanksName] = useState("")
+
+  // Single-choice selections held in state so the styled selection renders.
+  const [sessionValue, setSessionValue] = useState<number | null>(null)
+  const [talkFurther, setTalkFurther] = useState<string | null>(null)
+  const [role, setRole] = useState<string | null>(null)
+  const [industry, setIndustry] = useState<string | null>(null)
+  const [heardAbout, setHeardAbout] = useState<string | null>(null)
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setStatus("submitting")
+    setErrorMsg("")
+
+    const form = e.currentTarget
+    const formData = new FormData(form)
+    const email = String(formData.get("email") || "").trim()
+    const name = String(formData.get("name") || "").trim()
+    const company = String(formData.get("company") || "").trim()
+    const mostUseful = String(formData.get("mostUseful") || "").trim()
+    const biggestQuestion = String(formData.get("biggestQuestion") || "").trim()
+    const industryOther = String(formData.get("industryOther") || "").trim()
+
+    // Client-side guards for the styled (non-native) single-choice questions.
+    if (sessionValue === null) return fail("Please rate how valuable today's session was.")
+    if (talkFurther === null) return fail("Please tell us if you'd like to talk further.")
+    if (role === null) return fail("Please select your role.")
+    if (industry === null) return fail("Please select your industry.")
+    if (industry === OTHER_OPTION && industryOther.length === 0) return fail("Please specify your industry.")
+    if (heardAbout === null) return fail("Please tell us how you heard about the session.")
+
+    // Abort the request if it stalls, so the button can never get stuck on
+    // "Sending..." indefinitely — surface a retryable error instead.
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 15000)
+
+    try {
+      const res = await fetch("/api/lead-with-ops/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: controller.signal,
+        body: JSON.stringify({
+          email,
+          name,
+          company,
+          sessionValue,
+          mostUseful,
+          talkFurther,
+          role,
+          industry,
+          industryOther,
+          biggestQuestion,
+          heardAbout,
+        }),
+      })
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || "Submission failed. Please try again.")
+      }
+
+      const body = await res.json()
+      setThanksName(body?.data?.name || name)
+      setStatus("success")
+      form.reset()
+    } catch (err) {
+      setStatus("error")
+      if (err instanceof DOMException && err.name === "AbortError") {
+        setErrorMsg("That took too long to send. Please check your connection and try again.")
+      } else {
+        setErrorMsg(err instanceof Error ? err.message : "Something went wrong.")
+      }
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    function fail(message: string) {
+      setStatus("error")
+      setErrorMsg(message)
+    }
+  }
+
+  return (
+    <main className="bg-white min-h-screen text-[#041C32]">
+      <section className="relative pt-28 md:pt-32 pb-20 md:pb-28 px-6">
+        <div
+          className="absolute top-0 left-0 right-0 h-px pointer-events-none"
+          style={{ backgroundImage: `linear-gradient(to right, transparent, ${CORAL}55, transparent)` }}
+        />
+
+        <div className="relative z-10 max-w-2xl mx-auto">
+          {/* Header */}
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            className="flex items-center gap-3 flex-wrap mb-7"
+          >
+            <span className="inline-flex items-center gap-2">
+              <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: EMERALD }} />
+              <span className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] text-[#041C32] font-bold">
+                Lunch &amp; Learn Feedback
+              </span>
+            </span>
+          </motion.div>
+
+          <motion.h1
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.1 }}
+            className="font-(family-name:--font-geist-pixel-square) text-3xl md:text-5xl text-[#041C32] uppercase tracking-wide leading-[1.1] font-black mb-5"
+          >
+            Lead with Ops.{" "}
+            <span className="text-[#6F7883] font-medium block">Layer in AI.</span>
+          </motion.h1>
+
+          <motion.p
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.18 }}
+            className="text-[#6F7883] text-base md:text-lg leading-relaxed mb-10"
+          >
+            Thank you for spending your lunch with us. Ninety seconds of feedback shapes the next
+            session — and tells us who&apos;d like to keep the conversation going.
+          </motion.p>
+
+          {status === "success" ? (
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6 }}
+              className="border border-[#E1E4EA] bg-white p-7 md:p-9 relative"
+            >
+              <div className="absolute top-0 left-0 right-0 h-1" style={{ backgroundColor: EMERALD }} aria-hidden="true" />
+              <span
+                className="inline-block font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.3em] font-bold mb-4 px-2.5 py-1 text-[#041C32]"
+                style={{ backgroundColor: EMERALD }}
+              >
+                Received
+              </span>
+              <h2 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-3xl text-[#041C32] uppercase tracking-wide leading-tight mb-4">
+                Thank you{thanksName ? "," : "."}{" "}
+                {thanksName && <span className="text-[#6F7883] font-medium">{thanksName}.</span>}
+              </h2>
+              <p className="text-[#6F7883] text-sm md:text-base leading-relaxed">
+                Your feedback is in. If you asked to keep the conversation going, we&apos;ll be in touch.
+                Questions in the meantime?{" "}
+                <a href="mailto:VIP@434MEDIA.COM" className="text-[#041C32] hover:underline font-semibold">
+                  VIP@434MEDIA.COM
+                </a>
+                .
+              </p>
+            </motion.div>
+          ) : (
+            <motion.form
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.7, delay: 0.24 }}
+              onSubmit={handleSubmit}
+              className="border border-[#E1E4EA] bg-white p-6 md:p-8 space-y-7"
+            >
+              {/* Q1 — Email */}
+              <div>
+                <FieldLabel htmlFor="email">Email</FieldLabel>
+                <input id="email" name="email" type="email" required autoComplete="email" className={inputClass} placeholder="you@company.com" />
+              </div>
+
+              {/* Section: Today's session */}
+              <div className="h-px bg-[#E1E4EA]" />
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.3em] font-bold" style={{ color: CORAL }}>
+                Today&apos;s session
+              </p>
+
+              {/* Q2 — Session value 1–5 */}
+              <fieldset>
+                <legend className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-[#6F7883] font-bold mb-2 block">
+                  How valuable was today&apos;s session? <span style={{ color: CORAL }}>*</span>
+                </legend>
+                <div className="grid grid-cols-5 gap-1.5">
+                  {SESSION_SCALE.map((n) => {
+                    const isSelected = sessionValue === n
+                    return (
+                      <button
+                        key={n}
+                        type="button"
+                        onClick={() => setSessionValue(n)}
+                        className={`relative border p-3 transition-all duration-200 ${
+                          isSelected ? "border-transparent" : "border-[#E1E4EA] bg-white hover:border-[#041C32]/40"
+                        }`}
+                        style={isSelected ? { backgroundColor: EMERALD } : undefined}
+                        aria-pressed={isSelected}
+                        aria-label={`${n}${n === SESSION_VALUE_MIN ? ` — ${SESSION_VALUE_LOW_LABEL}` : ""}${n === SESSION_VALUE_MAX ? ` — ${SESSION_VALUE_HIGH_LABEL}` : ""}`}
+                      >
+                        <span className={`block font-(family-name:--font-geist-pixel-square) text-lg md:text-xl font-bold ${isSelected ? "text-[#041C32]" : "text-[#041C32]/70"}`}>
+                          {n}
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+                <div className="flex justify-between mt-2">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#6F7883]">{SESSION_VALUE_LOW_LABEL}</span>
+                  <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#6F7883]">{SESSION_VALUE_HIGH_LABEL}</span>
+                </div>
+              </fieldset>
+
+              {/* Q3 — Most useful */}
+              <div>
+                <FieldLabel htmlFor="mostUseful">What was most useful — or what would&apos;ve made it better?</FieldLabel>
+                <textarea id="mostUseful" name="mostUseful" required rows={4} className={`${inputClass} resize-y`} placeholder="A sentence or two is plenty." />
+              </div>
+
+              {/* Section: Keep the conversation going */}
+              <div className="h-px bg-[#E1E4EA]" />
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.3em] font-bold" style={{ color: CORAL }}>
+                Keep the conversation going
+              </p>
+
+              {/* Q4 — Talk further */}
+              <ChoiceGroup
+                legend="Would you like to talk further about AI in your operations?"
+                options={TALK_FURTHER_OPTIONS}
+                value={talkFurther}
+                onChange={setTalkFurther}
+              />
+
+              {/* Section: A bit about you */}
+              <div className="h-px bg-[#E1E4EA]" />
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.3em] font-bold" style={{ color: CORAL }}>
+                A bit about you
+              </p>
+
+              {/* Q5 / Q6 — Name + Company */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <FieldLabel htmlFor="name">Name</FieldLabel>
+                  <input id="name" name="name" type="text" required autoComplete="name" className={inputClass} placeholder="Jane Operator" />
+                </div>
+                <div>
+                  <FieldLabel htmlFor="company">Company</FieldLabel>
+                  <input id="company" name="company" type="text" required autoComplete="organization" className={inputClass} placeholder="Acme Co." />
+                </div>
+              </div>
+
+              {/* Q7 — Role */}
+              <ChoiceGroup legend="Your role" options={ROLE_OPTIONS} value={role} onChange={setRole} />
+
+              {/* Q8 — Industry (+ Other short answer) */}
+              <div>
+                <ChoiceGroup
+                  legend="Your industry"
+                  options={INDUSTRY_OPTIONS}
+                  value={industry}
+                  onChange={(v) => setIndustry(v)}
+                />
+                {industry === OTHER_OPTION && (
+                  <input
+                    name="industryOther"
+                    type="text"
+                    className={`${inputClass} mt-2`}
+                    placeholder="Tell us your industry"
+                    aria-label="Specify your industry"
+                  />
+                )}
+              </div>
+
+              {/* Q9 — Biggest question / blocker */}
+              <div>
+                <FieldLabel htmlFor="biggestQuestion">What&apos;s your single biggest question or blocker with AI right now?</FieldLabel>
+                <textarea id="biggestQuestion" name="biggestQuestion" required rows={3} className={`${inputClass} resize-y`} placeholder="The one thing you'd most like answered." />
+              </div>
+
+              {/* Section: Attribution */}
+              <div className="h-px bg-[#E1E4EA]" />
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.3em] font-bold" style={{ color: CORAL }}>
+                Attribution
+              </p>
+
+              {/* Q10 — Heard about */}
+              <ChoiceGroup
+                legend="How did you hear about today's session?"
+                options={HEARD_ABOUT_OPTIONS}
+                value={heardAbout}
+                onChange={setHeardAbout}
+              />
+
+              {status === "error" && errorMsg && (
+                <p className="text-xs font-(family-name:--font-geist-pixel-square)" style={{ color: CORAL }}>
+                  {errorMsg}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={status === "submitting"}
+                className="w-full text-[#041C32] font-(family-name:--font-geist-pixel-square) font-bold text-xs uppercase tracking-widest py-4 px-6 transition-all hover:bg-[#041C32] hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{ backgroundColor: CORAL }}
+              >
+                {status === "submitting" ? "Sending..." : "Send feedback"}
+              </button>
+
+              <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#6F7883] leading-relaxed">
+                Presented by Digital Canvas · 434 Media. Your responses are used to improve future sessions.
+              </p>
+            </motion.form>
+          )}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/lib/lead-with-ops-feedback.ts
+++ b/lib/lead-with-ops-feedback.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared option sets + types for the Lead with Ops. Layer in AI. post-event
+ * feedback form. Pure constants only (no server imports) so the client page and
+ * the server API route can both import from here and never drift out of sync.
+ *
+ * Mirrors the 10-question "Lunch and Learn Feedback" Google Form:
+ *   1. Email
+ *   2. How valuable was today's session? (1 = Very Valuable … 5 = Not Valuable)
+ *   3. What was most useful — or what would've made it better?
+ *   4. Would you like to talk further about AI in your operations?
+ *   5. Name
+ *   6. Company
+ *   7. Your Role
+ *   8. Your Industry
+ *   9. What's your single biggest question or blocker with AI right now?
+ *  10. How did you hear about today's session?
+ */
+
+/** Firestore collection (in the `digitalcanvas` database) for feedback rows. */
+export const FEEDBACK_COLLECTION = "event-feedback"
+
+/** Q2 — session value scale. 1 = Very Valuable, 5 = Not Valuable. */
+export const SESSION_VALUE_MIN = 1
+export const SESSION_VALUE_MAX = 5
+export const SESSION_VALUE_LOW_LABEL = "Very Valuable"
+export const SESSION_VALUE_HIGH_LABEL = "Not Valuable"
+
+/** Q4 — interest in a follow-up conversation. */
+export const TALK_FURTHER_OPTIONS = [
+  "Yes, let's set up a call",
+  "Maybe, send me the self-assessment and I'll reach out",
+  "Not right now, just here to learn",
+] as const
+
+/** Q7 — role. "Other" is a plain option (no free-text per the form). */
+export const ROLE_OPTIONS = [
+  "Owner / CEO / President",
+  "C-suite / Partner",
+  "VP / Director",
+  "Manager",
+  "Other",
+] as const
+
+/** Q8 — industry. "Other" reveals a short-answer field (per the form). */
+export const INDUSTRY_OPTIONS = [
+  "Commercial Real Estate",
+  "Private Equity",
+  "Construction",
+  "Financial Services",
+  "Family Office",
+  "Other",
+] as const
+
+/** Q10 — attribution. */
+export const HEARD_ABOUT_OPTIONS = [
+  "434 Media / Digital Canvas email",
+  "LinkedIn",
+  "Adam Carroll",
+  "A colleague or friend",
+  "VelocityTX",
+  "Other",
+] as const
+
+export type TalkFurther = (typeof TALK_FURTHER_OPTIONS)[number]
+export type Role = (typeof ROLE_OPTIONS)[number]
+export type Industry = (typeof INDUSTRY_OPTIONS)[number]
+export type HeardAbout = (typeof HEARD_ABOUT_OPTIONS)[number]
+
+/** The free-text "Other" sentinel shared by the industry field. */
+export const OTHER_OPTION = "Other"


### PR DESCRIPTION
## Summary
Adds a dedicated **`/workshops/lead-with-ops/feedback`** page — the 10-question post-event "Lunch and Learn Feedback" form — saving to the **`event-feedback`** collection in the `digitalcanvas` Firestore database. Mirrors the event page's system design (Carroll palette, geist-pixel-square headers, mono labels, motion fade-ins, bordered card, coral CTA, emerald selection, thank-you state).

## Files
- `lib/lead-with-ops-feedback.ts` — shared option sets + types (no server deps) so the client page and server route can't drift.
- `app/api/lead-with-ops/feedback/route.ts` — strict validation + single Firestore write. No email, no dedupe (an attendee may resubmit).
- `app/workshops/lead-with-ops/feedback/page.tsx` — form UI: 1–5 value scale, styled single-choice groups, conditional industry "Other" field, 15s fetch timeout.
- `app/workshops/lead-with-ops/feedback/layout.tsx` — metadata, `noindex`.

## Questions captured
Email · session value (1–5) · what was most useful · talk-further interest · name · company · role · industry (+Other) · biggest AI question/blocker · attribution.

## BotID note
Intentionally **not** behind Vercel BotID, unlike registration. The client BotID challenge can silently hang for legitimate attendees (privacy extensions / ad blockers return an empty body for the obfuscated challenge script, so the wrapped `fetch` never resolves and the submit button sticks on "Sending"). For a form we want every attendee to complete, reliable delivery beats bot protection on a low-value target. A 15s `AbortController` timeout guards against any other stall.

## Verification
- Page renders (200); valid submit saves a complete row; validation rejects bad enums / missing email / out-of-range value / `Other` industry without text (all 400).
- TypeScript + ESLint clean. Test rows cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)