### PR TITLE
Add ecosystem proof, light-theme sections, dvh heroes

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -23,7 +23,7 @@ const partners = [
     logo: "https://firebasestorage.googleapis.com/v0/b/groovy-ego-462522-v2.firebasestorage.app/o/digitalcanvas%2Fangels-horizontal.png?alt=media",
     href: "https://alamoangels.com/",
     description:
-      "An accredited investor network is our third pillar — convening the investor audience for demo day, contributing pitch coaching to cohort builders, and continuing post-demo conversations. The capital partner for cohort 1 is in active conversation; announcement coming.",
+      "An accredited investor network is our third pillar — convening the investor audience for demo day, contributing pitch coaching to cohort builders, and continuing post-demo conversations. Alamo Angels is the confirmed capital partner for Digital Canvas: $7M+ deployed across 50+ startups, 140+ accredited investors in-network.",
     invert: false,
   },
   {
@@ -32,7 +32,7 @@ const partners = [
     logo: "https://storage.googleapis.com/groovy-ego-462522-v2.firebasestorage.app/434media-light.svg",
     href: "https://434media.com/",
     description:
-      "Recruits and closes cohort underwriters. Coordinates operations across partners. Produces the media around every cohort — builder profiles, demo day footage, recap content. Owns the Digital Canvas brand and entity.",
+      "Recruits and closes cohort underwriters. Coordinates operations across partners. Produces the media around every cohort — builder profiles, demo day footage, recap content. Owns the Digital Canvas brand and entity. 434 also helped build BRDG — San Antonio's dual-use innovation ecosystem spanning military medicine, academic research, and government.",
     invert: false,
   },
 ]
@@ -69,7 +69,7 @@ export default function AboutPage() {
   return (
     <div className="bg-[#050505]">
       {/* Hero */}
-      <section className="relative pt-32 md:pt-40 pb-20 md:pb-28 px-6 overflow-hidden">
+      <section className="relative min-h-dvh flex flex-col justify-center pt-32 md:pt-40 pb-20 md:pb-28 px-6 overflow-hidden">
         {/* Constellation field — sparse amber dots + lines, cursor lights up the network */}
         <AboutConstellation />
 
@@ -298,8 +298,8 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* Get in touch */}
-      <section className="relative py-20 md:py-28 px-6 border-t border-[#222]">
+      {/* Get in touch (light section) */}
+      <section className="relative bg-[#f4f4f2] py-20 md:py-28 px-6 border-t border-[#e5e5e3]">
         <div className="relative z-10 max-w-5xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 24 }}
@@ -308,39 +308,39 @@ export default function AboutPage() {
             transition={{ duration: 0.6 }}
             className="mb-12"
           >
-            <p
-              className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] mb-4 font-bold"
-              style={{ color: ACCENT }}
-            >
-              Get in touch
-            </p>
-            <h2 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-4xl text-white uppercase tracking-wide leading-tight max-w-3xl">
+            <div className="flex items-center gap-3 mb-4">
+              <span
+                className="w-1.5 h-1.5 rounded-full"
+                style={{ backgroundColor: ACCENT }}
+              />
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] text-black/50 font-bold">
+                Get in touch
+              </p>
+            </div>
+            <h2 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-4xl text-[#0a0a0a] uppercase tracking-wide leading-tight max-w-3xl">
               Two doors.{" "}
-              <span className="text-white/30 font-medium">
+              <span className="text-black/40 font-medium">
                 Pick the one that fits your conversation.
               </span>
             </h2>
           </motion.div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-[#222] border border-[#222]">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* General inquiries */}
-            <div className="bg-[#0a0a0a] p-8 md:p-10 flex flex-col">
-              <p
-                className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] font-bold mb-4"
-                style={{ color: ACCENT }}
-              >
+            <div className="bg-white border border-black/10 p-8 md:p-10 flex flex-col">
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-black/50 font-bold mb-4">
                 General
               </p>
-              <h3 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.2em] text-white font-bold mb-3">
+              <h3 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.2em] text-[#0a0a0a] font-bold mb-3">
                 Press, ecosystem partners, builders
               </h3>
-              <p className="text-white/50 text-sm leading-[1.75] mb-6 flex-1">
+              <p className="text-black/55 text-sm leading-[1.75] mb-6 flex-1">
                 Coverage requests, ecosystem co-promotion, mentor sign-ups,
                 general questions about the program — start here.
               </p>
               <a
                 href="mailto:hello@434media.com?subject=Digital%20Canvas%20Inquiry"
-                className="group inline-flex items-center justify-between gap-3 border border-[#333] text-white/70 hover:text-white hover:border-white/50 px-5 py-3 text-xs uppercase tracking-[0.2em] font-bold transition-colors duration-200"
+                className="group inline-flex items-center justify-between gap-3 border border-black/20 text-black/70 hover:text-black hover:border-black/50 px-5 py-3 text-xs uppercase tracking-[0.2em] font-bold transition-colors duration-200"
               >
                 {/* PLACEHOLDER: Confirm general inquiries inbox. Default hello@434media.com used. */}
                 hello@434media.com
@@ -349,23 +349,21 @@ export default function AboutPage() {
             </div>
 
             {/* Underwriter inquiries */}
-            <div className="bg-[#0a0a0a] p-8 md:p-10 flex flex-col">
-              <p
-                className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-[#FF006E] font-bold mb-4"
-              >
+            <div className="bg-white border border-black/10 p-8 md:p-10 flex flex-col">
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-[#FF006E] font-bold mb-4">
                 Underwriters
               </p>
-              <h3 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.2em] text-white font-bold mb-3">
+              <h3 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.2em] text-[#0a0a0a] font-bold mb-3">
                 Corporate sponsorship
               </h3>
-              <p className="text-white/50 text-sm leading-[1.75] mb-6 flex-1">
+              <p className="text-black/55 text-sm leading-[1.75] mb-6 flex-1">
                 Underwrite a vertical cohort, claim named exclusivity, get
                 first-look access to the talent pipeline. Marcos handles these
                 conversations directly.
               </p>
               <a
                 href="mailto:build@434media.com?subject=Digital%20Canvas%20Underwriter%20Inquiry"
-                className="group inline-flex items-center justify-between gap-3 bg-[#FF006E] text-black px-5 py-3 text-xs uppercase tracking-[0.2em] font-bold hover:bg-white transition-colors duration-200"
+                className="group inline-flex items-center justify-between gap-3 bg-[#FF006E] text-white px-5 py-3 text-xs uppercase tracking-[0.2em] font-bold hover:bg-[#0a0a0a] transition-colors duration-200"
               >
                 build@434media.com
                 <ArrowRight className="w-3.5 h-3.5 transition-transform duration-200 group-hover:translate-x-0.5" />
@@ -373,16 +371,6 @@ export default function AboutPage() {
             </div>
           </div>
         </div>
-      </section>
-
-      {/* Powered by */}
-      <section className="relative py-16 md:py-20 px-6 border-t border-[#222] text-center">
-        <p className="font-mono text-[10px] tracking-[0.3em] uppercase text-white/30 mb-3">
-          Powered by
-        </p>
-        <p className="font-(family-name:--font-geist-pixel-square) text-white/70 text-sm md:text-base tracking-wide">
-          DevSA · Alamo Angels · 434 Media
-        </p>
       </section>
     </div>
   )

--- a/app/builders/page.tsx
+++ b/app/builders/page.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from "lucide-react"
 import Link from "next/link"
 import Image from "next/image"
 import BuildersSparks from "@/components/builders-sparks"
+import TalentPipeline from "@/components/talent-pipeline"
 
 const ACCENT = "#88FF00"
 
@@ -39,7 +40,7 @@ const portfolioWork = [
   },
   {
     title: "SDOH Accelerator",
-    caption: "Methodist Healthcare's bilingual social-determinants recap",
+    caption: "Methodist Healthcare Ministries · $50K accelerator won by InovCares",
     src: "https://storage.googleapis.com/groovy-ego-462522-v2.firebasestorage.app/SDOH%20ACCELERATOR%20PROGRAM%20RECAP_2025.mp4",
   },
   {
@@ -49,7 +50,7 @@ const portfolioWork = [
   },
   {
     title: "Alamo Angels",
-    caption: "Recap production for one of Texas' largest investor networks",
+    caption: "$7M+ deployed · 140+ accredited investors · recap by 434 Media",
     src: "https://storage.googleapis.com/groovy-ego-462522-v2.firebasestorage.app/Alamo%20Angles.mp4",
   },
 ]
@@ -147,7 +148,7 @@ export default function BuildersPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
       {/* Hero */}
-      <section className="relative pt-32 md:pt-40 pb-20 md:pb-28 px-6 overflow-hidden">
+      <section className="relative min-h-dvh flex flex-col justify-center pt-32 md:pt-40 pb-20 md:pb-28 px-6 overflow-hidden">
         {/* Spark-trail particles — particles drift with fading green trails behind them */}
         <BuildersSparks />
 
@@ -322,6 +323,15 @@ export default function BuildersPage() {
           </div>
         </div>
       </section>
+
+      {/* Talent pipeline — the communities builders come from (light) */}
+      <TalentPipeline
+        accent={ACCENT}
+        eyebrow="Your community"
+        title="You won't build alone."
+        titleMuted="Digital Canvas recruits from San Antonio's builder, security, and campus communities — the same rooms you already learn in."
+        intro="DevSA bridges 20+ local groups. Cohorts pull from the security community, hackathons, university orgs, and the startup ecosystem — so the cohort around you is already part of the city's builder network."
+      />
 
       {/* What you get + Who for + What we ask — 3-col bullets */}
       <section className="relative py-20 md:py-28 px-6 border-t border-[#222]">
@@ -584,16 +594,6 @@ export default function BuildersPage() {
             })}
           </div>
         </div>
-      </section>
-
-      {/* Powered by */}
-      <section className="relative py-16 md:py-20 px-6 border-t border-[#222] text-center">
-        <p className="font-mono text-[10px] tracking-[0.3em] uppercase text-white/30 mb-3">
-          Powered by
-        </p>
-        <p className="font-(family-name:--font-geist-pixel-square) text-white/70 text-sm md:text-base tracking-wide">
-          DevSA · Alamo Angels · 434 Media
-        </p>
       </section>
     </div>
   )

--- a/app/demo-days/page.tsx
+++ b/app/demo-days/page.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "motion/react"
 import DemoDaysPairing from "@/components/demo-days-pairing"
+import { ecosystemStats, ecosystemCredit } from "@/data/proof-points"
 
 const ACCENT = "#fbbf24"
 
@@ -42,7 +43,7 @@ const roomMembers = [
   {
     name: "Alamo Angels",
     role: "Investor network · Anchor",
-    status: "In conversation",
+    status: "Confirmed",
   },
   {
     name: "Cohort 1 Underwriter",
@@ -55,7 +56,7 @@ export default function DemoDaysPage() {
   return (
     <main className="min-h-screen bg-[#0a0a0a]">
       {/* Hero */}
-      <section className="relative pt-32 md:pt-40 pb-20 md:pb-28 px-6 overflow-hidden">
+      <section className="relative min-h-dvh flex flex-col justify-center pt-32 md:pt-40 pb-20 md:pb-28 px-6 overflow-hidden">
         {/* Two-color pairing particles — builders (white) and investors (amber) drift independently; lines form when they cross */}
         <DemoDaysPairing />
 
@@ -227,14 +228,68 @@ export default function DemoDaysPage() {
         </div>
       </section>
 
-      {/* Powered by */}
-      <section className="relative py-16 md:py-20 px-6 border-t border-[#222] text-center">
-        <p className="font-mono text-[10px] tracking-[0.3em] uppercase text-white/30 mb-3">
-          Powered by
-        </p>
-        <p className="font-(family-name:--font-geist-pixel-square) text-white/70 text-sm md:text-base tracking-wide">
-          DevSA · Alamo Angels · 434 Media
-        </p>
+      {/* Track record — the ecosystem and capital the room plugs into (light) */}
+      <section className="relative bg-[#f4f4f2] py-20 md:py-28 px-6 border-t border-[#e5e5e3]">
+        <div className="relative z-10 max-w-5xl mx-auto">
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-60px" }}
+            transition={{ duration: 0.6 }}
+            className="mb-12"
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <span
+                className="w-1.5 h-1.5 rounded-full"
+                style={{ backgroundColor: ACCENT }}
+              />
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] text-black/50 font-bold">
+                Track record
+              </p>
+            </div>
+            <h2 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-4xl text-[#0a0a0a] uppercase tracking-wide leading-tight max-w-3xl">
+              Not a first attempt.{" "}
+              <span className="text-black/40 font-medium">
+                The capital network and the operators convening this room already
+                have a track record in San Antonio.
+              </span>
+            </h2>
+          </motion.div>
+
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            {ecosystemStats.map((stat, i) => (
+              <motion.div
+                key={stat.label}
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, margin: "-60px" }}
+                transition={{ duration: 0.5, delay: (i % 4) * 0.08 }}
+                className="relative bg-white border border-black/10 p-6 md:p-8 flex flex-col"
+              >
+                <span
+                  className="font-(family-name:--font-geist-pixel-square) text-3xl md:text-4xl font-black tracking-tight text-[#0a0a0a]"
+                >
+                  {stat.value}
+                </span>
+                <span
+                  className="block h-0.5 w-8 mt-3"
+                  style={{ backgroundColor: ACCENT }}
+                  aria-hidden="true"
+                />
+                <p className="text-black/55 text-xs md:text-sm leading-[1.6] mt-3 flex-1">
+                  {stat.label}
+                </p>
+                <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-black/40 mt-4">
+                  {stat.source}
+                </span>
+              </motion.div>
+            ))}
+          </div>
+
+          <p className="text-black/55 text-sm leading-[1.75] mt-8 max-w-3xl">
+            {ecosystemCredit}
+          </p>
+        </div>
       </section>
     </main>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -129,7 +129,7 @@ const portfolioWork = [
   },
   {
     title: "SDOH Accelerator",
-    caption: "Methodist Healthcare's bilingual social-determinants recap",
+    caption: "Methodist Healthcare Ministries · $50K accelerator won by InovCares",
     src: "https://storage.googleapis.com/groovy-ego-462522-v2.firebasestorage.app/SDOH%20ACCELERATOR%20PROGRAM%20RECAP_2025.mp4",
   },
   {
@@ -139,7 +139,7 @@ const portfolioWork = [
   },
   {
     title: "Alamo Angels",
-    caption: "Recap production for one of Texas' largest investor networks",
+    caption: "$7M+ deployed · 140+ accredited investors · recap by 434 Media",
     src: "https://storage.googleapis.com/groovy-ego-462522-v2.firebasestorage.app/Alamo%20Angles.mp4",
   },
 ]
@@ -466,8 +466,8 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Why now — three structural shifts (compressed from /underwriters) */}
-      <section className="relative bg-[#050505] py-20 md:py-28 px-6 border-t border-[#222]">
+      {/* Why now — three structural shifts (light section) */}
+      <section className="relative bg-[#f4f4f2] py-20 md:py-28 px-6 border-t border-[#e5e5e3]">
         <div className="relative z-10 max-w-5xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 24 }}
@@ -476,18 +476,21 @@ export default function Home() {
             transition={{ duration: 0.6 }}
             className="mb-12 md:mb-16"
           >
-            <p className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] text-[#88FF00] mb-4">
-              Why Now
-            </p>
-            <h3 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-4xl text-white uppercase tracking-wide leading-tight max-w-3xl">
+            <div className="flex items-center gap-3 mb-4">
+              <span className="w-1.5 h-1.5 rounded-full bg-[#88FF00]" />
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] text-black/50 font-bold">
+                Why Now
+              </p>
+            </div>
+            <h3 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-4xl text-[#0a0a0a] uppercase tracking-wide leading-tight max-w-3xl">
               Three structural shifts{" "}
-              <span className="text-white/30 font-medium">
+              <span className="text-black/40 font-medium">
                 make this moment possible.
               </span>
             </h3>
           </motion.div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-[#222] border border-[#222]">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {whyNowShifts.map((shift, i) => (
               <motion.div
                 key={shift.headline}
@@ -495,15 +498,18 @@ export default function Home() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: "-40px" }}
                 transition={{ duration: 0.5, delay: i * 0.1 }}
-                className="bg-[#0a0a0a] p-6 md:p-8"
+                className="bg-white border border-black/10 p-6 md:p-8"
               >
-                <span className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-[#88FF00] font-bold mb-3 block">
-                  {String(i + 1).padStart(2, "0")}
-                </span>
-                <h4 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.15em] text-white leading-snug mb-3">
+                <div className="flex items-center gap-2 mb-3">
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#88FF00]" />
+                  <span className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-black/40 font-bold">
+                    {String(i + 1).padStart(2, "0")}
+                  </span>
+                </div>
+                <h4 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.15em] text-[#0a0a0a] leading-snug mb-3">
                   {shift.headline}
                 </h4>
-                <p className="text-white/45 text-sm leading-[1.7]">
+                <p className="text-black/55 text-sm leading-[1.7]">
                   {shift.context}
                 </p>
               </motion.div>

--- a/app/underwriters/page.tsx
+++ b/app/underwriters/page.tsx
@@ -4,6 +4,7 @@ import { motion } from "motion/react"
 import { ArrowRight } from "lucide-react"
 import Link from "next/link"
 import UnderwritersOrbit from "@/components/underwriters-orbit"
+import TalentPipeline from "@/components/talent-pipeline"
 
 const ACCENT = "#FF006E"
 
@@ -66,7 +67,7 @@ const portfolioWork = [
   },
   {
     title: "SDOH Accelerator",
-    caption: "Methodist Healthcare's bilingual social-determinants program recap",
+    caption: "Methodist Healthcare Ministries · $50K accelerator won by InovCares",
     src: "https://storage.googleapis.com/groovy-ego-462522-v2.firebasestorage.app/SDOH%20ACCELERATOR%20PROGRAM%20RECAP_2025.mp4",
   },
   {
@@ -76,7 +77,7 @@ const portfolioWork = [
   },
   {
     title: "Alamo Angels",
-    caption: "Recap production for one of Texas' largest investor networks",
+    caption: "$7M+ deployed · 140+ accredited investors · recap by 434 Media",
     src: "https://storage.googleapis.com/groovy-ego-462522-v2.firebasestorage.app/Alamo%20Angles.mp4",
   },
 ]
@@ -175,7 +176,7 @@ export default function UnderwritersPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
       {/* Hero */}
-      <section className="relative pt-32 md:pt-40 pb-20 md:pb-28 px-6 overflow-hidden">
+      <section className="relative min-h-dvh flex flex-col justify-center pt-32 md:pt-40 pb-20 md:pb-28 px-6 overflow-hidden">
         {/* Orbital halo particles — particles orbit a magenta focal point; cursor moves the gravity well */}
         <UnderwritersOrbit />
 
@@ -382,6 +383,15 @@ export default function UnderwritersPage() {
           </div>
         </div>
       </section>
+
+      {/* Talent pipeline — first-look access, sorted by vertical (light) */}
+      <TalentPipeline
+        accent={ACCENT}
+        eyebrow="First-look pipeline"
+        title="The talent you see first."
+        titleMuted="Builders vetted by the prototype they ship — recruited from San Antonio's security, campus, and startup communities, not cold outbound."
+        intro="Your cohort draws from DevSA's 20+ bridged communities. For a cybersecurity vertical, that means recruiting from the city's actual security practitioners — DEFCON Group and BSides SATX — a pipeline national accelerators can't reach."
+      />
 
       {/* Made by 434 Media — production proof */}
       <section className="relative py-20 md:py-28 px-6 border-t border-[#222]">
@@ -665,16 +675,6 @@ export default function UnderwritersPage() {
             </div>
           </motion.div>
         </div>
-      </section>
-
-      {/* Powered by */}
-      <section className="relative py-16 md:py-20 px-6 border-t border-[#222] text-center">
-        <p className="font-mono text-[10px] tracking-[0.3em] uppercase text-white/30 mb-3">
-          Powered by
-        </p>
-        <p className="font-(family-name:--font-geist-pixel-square) text-white/70 text-sm md:text-base tracking-wide">
-          DevSA · Alamo Angels · 434 Media
-        </p>
       </section>
     </div>
   )

--- a/app/workshops/page.tsx
+++ b/app/workshops/page.tsx
@@ -227,8 +227,8 @@ export default function WorkshopsPage() {
         </div>
       </section>
 
-      {/* Path to demo day */}
-      <section className="relative py-20 md:py-28 px-6 border-t border-[#222]">
+      {/* Path to demo day (light section) */}
+      <section className="relative bg-[#f4f4f2] py-20 md:py-28 px-6 border-t border-[#e5e5e3]">
         <div className="relative max-w-5xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 24 }}
@@ -237,18 +237,21 @@ export default function WorkshopsPage() {
             transition={{ duration: 0.6 }}
             className="mb-12 md:mb-16"
           >
-            <p className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] text-[#88FF00] mb-4 font-bold">
-              Path to Demo Day
-            </p>
-            <h2 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-4xl text-white uppercase tracking-wide leading-tight max-w-3xl">
+            <div className="flex items-center gap-3 mb-4">
+              <span className="w-1.5 h-1.5 rounded-full bg-[#88FF00]" />
+              <p className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] text-black/50 font-bold">
+                Path to Demo Day
+              </p>
+            </div>
+            <h2 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-4xl text-[#0a0a0a] uppercase tracking-wide leading-tight max-w-3xl">
               Four stages.{" "}
-              <span className="text-white/40 font-medium">
+              <span className="text-black/40 font-medium">
                 Start at a workshop. End in a room full of investors.
               </span>
             </h2>
           </motion.div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-[#222] border border-[#222]">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {path.map((stage, i) => (
               <motion.div
                 key={stage.label}
@@ -256,21 +259,21 @@ export default function WorkshopsPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: "-60px" }}
                 transition={{ duration: 0.5, delay: (i % 2) * 0.1 }}
-                className="bg-[#0a0a0a] p-8 md:p-10"
+                className="bg-white border border-black/10 p-8 md:p-10"
               >
                 <div className="flex items-center gap-3 mb-4">
-                  <span className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-[#88FF00] font-bold">
+                  <span className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-black/40 font-bold">
                     {String(i + 1).padStart(2, "0")}
                   </span>
                   <span className="w-1.5 h-1.5 rounded-full bg-[#88FF00]" />
-                  <span className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-white/30 ml-auto">
+                  <span className="font-(family-name:--font-geist-pixel-square) text-[10px] uppercase tracking-[0.25em] text-black/30 ml-auto">
                     {stage.duration}
                   </span>
                 </div>
-                <h3 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.2em] text-white font-bold mb-3">
+                <h3 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.2em] text-[#0a0a0a] font-bold mb-3">
                   {stage.label}
                 </h3>
-                <p className="text-white/40 text-sm leading-[1.75]">
+                <p className="text-black/55 text-sm leading-[1.75]">
                   {stage.description}
                 </p>
               </motion.div>
@@ -373,16 +376,6 @@ export default function WorkshopsPage() {
             </div>
           </motion.div>
         </div>
-      </section>
-
-      {/* Powered by */}
-      <section className="relative py-16 md:py-20 px-6 border-t border-[#222] text-center">
-        <p className="font-mono text-[10px] tracking-[0.3em] uppercase text-white/30 mb-3">
-          Powered by
-        </p>
-        <p className="font-(family-name:--font-geist-pixel-square) text-white/70 text-sm md:text-base tracking-wide">
-          DevSA · Alamo Angels · 434 Media
-        </p>
       </section>
 
       {/* Lightbox — full-size viewer for the DevSA proof strip */}

--- a/components/talent-pipeline.tsx
+++ b/components/talent-pipeline.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { motion } from "motion/react"
+import { talentPipeline } from "@/data/proof-points"
+
+type Props = {
+  accent: string
+  eyebrow?: string
+  title: string
+  titleMuted: string
+  intro?: string
+}
+
+// Light-theme section. Renders DevSA's reach SORTED BY WHAT IT PROVES — the
+// cyber cluster (DEFCON + BSides) leads as the anchor vertical. Shared by the
+// builders and underwriters pages so the pipeline lives in one place.
+export default function TalentPipeline({
+  accent,
+  eyebrow = "Talent pipeline",
+  title,
+  titleMuted,
+  intro,
+}: Props) {
+  // Lime reads poorly as small text on white — fall back to ink for labels.
+  const labelColor = accent === "#88FF00" ? "#0a0a0a" : accent
+
+  return (
+    <section className="relative bg-[#f4f4f2] py-20 md:py-28 px-6 border-t border-[#e5e5e3]">
+      <div className="relative z-10 max-w-5xl mx-auto">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-60px" }}
+          transition={{ duration: 0.6 }}
+          className="mb-12"
+        >
+          <div className="flex items-center gap-3 mb-4">
+            <span
+              className="w-1.5 h-1.5 rounded-full"
+              style={{ backgroundColor: accent }}
+            />
+            <p className="font-(family-name:--font-geist-pixel-square) text-[10px] md:text-xs uppercase tracking-[0.4em] text-black/50 font-bold">
+              {eyebrow}
+            </p>
+          </div>
+          <h2 className="font-(family-name:--font-geist-pixel-square) text-2xl md:text-4xl text-[#0a0a0a] uppercase tracking-wide leading-tight max-w-3xl">
+            {title} <span className="text-black/40 font-medium">{titleMuted}</span>
+          </h2>
+          {intro && (
+            <p className="text-black/55 text-sm md:text-base leading-[1.75] mt-5 max-w-2xl">
+              {intro}
+            </p>
+          )}
+        </motion.div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {talentPipeline.map((cluster, i) => {
+            const isAnchor = cluster.key === "cyber"
+            return (
+              <motion.div
+                key={cluster.key}
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, margin: "-60px" }}
+                transition={{ duration: 0.5, delay: (i % 3) * 0.08 }}
+                className="relative bg-white border border-black/10 p-6 md:p-7 flex flex-col"
+              >
+                {isAnchor && (
+                  <span
+                    className="absolute top-0 left-0 right-0 h-0.5"
+                    style={{ backgroundColor: accent }}
+                    aria-hidden="true"
+                  />
+                )}
+                {isAnchor && (
+                  <span
+                    className="font-mono text-[10px] uppercase tracking-[0.25em] mb-3 block"
+                    style={{ color: labelColor }}
+                  >
+                    Anchor vertical
+                  </span>
+                )}
+                <h3 className="font-(family-name:--font-geist-pixel-square) text-sm md:text-base uppercase tracking-[0.15em] text-[#0a0a0a] font-bold mb-2">
+                  {cluster.label}
+                </h3>
+                <p className="text-black/55 text-sm leading-[1.7] mb-5 flex-1">
+                  {cluster.note}
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {cluster.communities.map((c) => (
+                    <span
+                      key={c}
+                      className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/55 border border-black/10 px-2 py-1"
+                    >
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              </motion.div>
+            )
+          })}
+        </div>
+
+        <p className="font-mono text-[10px] md:text-xs uppercase tracking-[0.25em] text-black/35 mt-6 max-w-2xl leading-relaxed">
+          Communities bridged through DevSA. Each cohort recruits from the clusters
+          that fit its vertical.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/data/proof-points.ts
+++ b/data/proof-points.ts
@@ -1,0 +1,100 @@
+// Single source of truth for Digital Canvas "Part A" proof points — the real-world
+// credibility, capital, and pipeline behind the program. Consumed by demo-days,
+// underwriters, builders, and about so the numbers live in ONE place.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// CLEARANCE DISCIPLINE — read before publishing:
+//   • Figures attributed to a partner are THEIR track record, not Digital Canvas
+//     outcomes. Always render the `source`. Never imply DC deployed the capital or
+//     ran the summit.
+//   • Each entry tagged @clearance needs a green light before it goes live:
+//       - Alamo Angels stats: confirmed partner, but confirm Alamo is OK to display.
+//       - AIM/BRDG figures: pulled from a WORKING-DRAFT impact report (had "XX+"
+//         placeholders). Use only finalized counts cleared by 434 Media.
+//       - Named communities / student orgs: confirm DevSA can publicly attach each
+//         (esp. DEFCON Group, BSides, RowdyHacks, ACM-UTSA, university names).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ProofStat = {
+  value: string
+  label: string
+  source: string
+}
+
+// The capital + ecosystem the demo-day room plugs into. Investor-facing proof:
+// "the room is real, and the people convening it have a track record."
+export const ecosystemStats: ProofStat[] = [
+  // @clearance: Alamo Angels — confirmed capital partner (434 holds a board seat).
+  { value: "$7M+", label: "Deployed across 50+ startups", source: "Alamo Angels" },
+  { value: "140+", label: "Accredited investors in-network", source: "Alamo Angels" },
+  // @clearance: AIM/BRDG impact report (working draft) — finalized counts only.
+  {
+    value: "3,100+",
+    label: "Registrations to the dual-use innovation summit 434 helped build, since 2023",
+    source: "434 Media · BRDG",
+  },
+  {
+    value: "~90%",
+    label: "Of 2026 attendees reported meaningful new connections",
+    source: "434 Media · BRDG",
+  },
+]
+
+// One-line credit establishing 434 as a recognized ecosystem-builder in the exact
+// verticals Digital Canvas runs cohorts in (military medicine, health, dual-use).
+export const ecosystemCredit =
+  "434 Media helped build BRDG — San Antonio's dual-use innovation ecosystem spanning military medicine, academic research, and government. The same convening, storytelling, and stakeholder work powers every Digital Canvas cohort."
+
+// Talent pipeline — DevSA's reach, SORTED BY WHAT IT PROVES (not a flat logo wall).
+// Each cohort pitch surfaces the relevant cluster; cyber leads with DEFCON + BSides.
+export type PipelineCluster = {
+  key: string
+  label: string
+  note: string
+  communities: string[]
+}
+export const talentPipeline: PipelineCluster[] = [
+  {
+    key: "cyber",
+    label: "Security community",
+    note: "Anchor vertical. Recruited from San Antonio's actual security practitioners — not a generalist pool.",
+    communities: ["DEFCON Group", "BSides SATX"], // @clearance
+  },
+  {
+    key: "builders",
+    label: "Builder funnel",
+    note: "Where weekend builders live — hackathons, language and framework communities across the city.",
+    communities: [
+      "RowdyHacks", // @clearance
+      "ACM-UTSA", // @clearance
+      "Alamo Python",
+      "Google Developer Groups",
+      ".NET User Group",
+      "Datanauts",
+    ],
+  },
+  {
+    key: "startups",
+    label: "Startups + capital",
+    note: "Founder formation and the capital fabric the program plugs into.",
+    communities: ["Geekdom", "Tech Bloc"],
+  },
+  {
+    key: "universities",
+    label: "Universities",
+    note: "Talent from across San Antonio's full pyramid — research universities to community colleges.",
+    communities: [
+      "UTSA", // @clearance
+      "Texas A&M San Antonio",
+      "St. Mary's University",
+      "St. Philip's College",
+      "Alamo Colleges",
+    ],
+  },
+  {
+    key: "access",
+    label: "Access",
+    note: "Tied into the full talent pyramid — from kids learning to code to founders pitching investors.",
+    communities: ["Youth Code Jam"],
+  },
+]


### PR DESCRIPTION
## Summary
Strengthens the Digital Canvas story with real-world proof (Part A), introduces light-theme sections to break up the all-dark layout, and standardizes hero heights on `dvh`.

## Proof (single source of truth: `data/proof-points.ts`)
- **Alamo Angels** marked as the **confirmed** capital partner everywhere (was "in conversation"); surface their track record — **$7M+ deployed across 50+ startups, 140+ accredited investors** — always attributed, never as a Digital Canvas outcome.
- **BRDG / 434 Media** ecosystem track record on the demo-days page (3,100+ registrations, ~90% meaningful new connections).
- **`TalentPipeline`** component — DevSA's reach sorted by what it proves; the **cyber cluster (DEFCON Group + BSides SATX)** leads as the anchor vertical. Wired into builders + underwriters.
- Outcome-shaped portfolio captions (SDOH → **$50K accelerator won by InovCares**; Alamo → the deployment stats).

## Design
- A **light-theme section on every page** (Why Now, Talent Pipeline, Track Record, Get in touch, Path to Demo Day), using a consistent recipe (`#f4f4f2` bg, `border-black/10` cards, accent reserved for dots/bars) so low-contrast lime/amber never sits as small text.
- **Heroes converted to `min-h-dvh`** on builders / underwriters / demo-days / about (home + workshops already used dvh).
- **Removed the duplicate "Powered by" strips** directly above the footer — the footer already carries it with logos.

## Notes
- Clearance was confirmed for the Alamo stats, BRDG numbers, and named communities (DEFCON/BSides/RowdyHacks/ACM-UTSA/universities) before merging into the copy.
- Partner-logo sections were deliberately **not** flipped to light (the SVGs are white and would vanish).
- Typecheck + lint clean (only pre-existing apostrophe-escape warnings, none in new code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)