### PR TITLE
Add post-event thank-you email + KBYG venue-change update

### DIFF
--- a/app/api/lead-with-ops/send-test/route.ts
+++ b/app/api/lead-with-ops/send-test/route.ts
@@ -4,9 +4,11 @@ import {
   confirmationEmailHtml,
   kbygEmailHtml,
   reminderEmailHtml,
+  thankYouEmailHtml,
   confirmationEmailText,
   kbygEmailText,
   reminderEmailText,
+  thankYouEmailText,
   generateLeadWithOpsIcs,
   buildListUnsubscribeHeader,
 } from "@/lib/emails/lead-with-ops"
@@ -44,7 +46,7 @@ const TEST_RECIPIENTS = [
   { email: "jesse@434media.com", firstName: "Jesse", lastName: "Hernandez" },
 ]
 
-type TemplateKey = "confirmation" | "kbyg" | "reminder"
+type TemplateKey = "confirmation" | "kbyg" | "reminder" | "thankyou"
 
 export async function POST(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -58,9 +60,9 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 
-  if (!template || !["confirmation", "kbyg", "reminder"].includes(template)) {
+  if (!template || !["confirmation", "kbyg", "reminder", "thankyou"].includes(template)) {
     return NextResponse.json(
-      { error: "Missing or invalid `template` query param. Use: confirmation | kbyg | reminder. (Invite broadcasts are sent from the 434 Media admin app.)" },
+      { error: "Missing or invalid `template` query param. Use: confirmation | kbyg | reminder | thankyou. (Invite broadcasts are sent from the 434 Media admin app.)" },
       { status: 400 },
     )
   }
@@ -104,7 +106,7 @@ export async function POST(request: Request) {
   let attachments: Attachment[] | undefined
   if (template === "kbyg") {
     attachments = [{ filename: CAMPUS_MAP_FILENAME, path: CAMPUS_MAP_URL }]
-  } else if (template === "reminder") {
+  } else if (template === "reminder" || template === "thankyou") {
     attachments = undefined
   } else {
     attachments = [
@@ -133,6 +135,10 @@ export async function POST(request: Request) {
       subject = "Save the date: Lead with Ops. Layer in AI. is June 18"
       html = reminderEmailHtml({ firstName: recipient.firstName, email: recipient.email })
       text = reminderEmailText({ firstName: recipient.firstName, email: recipient.email })
+    } else if (template === "thankyou") {
+      subject = "Thank you for joining us for Lead with Ops. Layer in AI."
+      html = thankYouEmailHtml({ firstName: recipient.firstName, email: recipient.email })
+      text = thankYouEmailText({ firstName: recipient.firstName, email: recipient.email })
     } else {
       subject = "Tomorrow: What to know before Lead with Ops. Layer in AI."
       html = kbygEmailHtml({ firstName: recipient.firstName, email: recipient.email })

--- a/app/api/lead-with-ops/send-thankyou/route.ts
+++ b/app/api/lead-with-ops/send-thankyou/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from "next/server"
+import { Resend } from "resend"
+import { getDigitalCanvasDb } from "@/lib/firebase-admin"
+import {
+  EVENT_ID,
+  EVENT_COLLECTION,
+  sendThankYou,
+} from "@/lib/emails/lead-with-ops-resend"
+
+/**
+ * Send the post-event thank-you email to registrants, personalized with each
+ * recipient's first name from their registration record (unlike the test-send
+ * endpoint, which addresses unknown recipients as "Friend").
+ *
+ * Sends immediately (no scheduling). The email carries a stable idempotency key
+ * and each registrant doc is stamped `thankYouSent`, so re-running skips anyone
+ * already thanked unless force=true.
+ *
+ * Usage:
+ *   POST /api/lead-with-ops/send-thankyou?secret=...&emails=a@x.com,b@y.com
+ *   POST /api/lead-with-ops/send-thankyou?secret=...&all=true
+ *   POST /api/lead-with-ops/send-thankyou?secret=...&emails=...&dryRun=true
+ *   POST /api/lead-with-ops/send-thankyou?secret=...&emails=...&force=true
+ *
+ * Provide exactly one target selector: `emails` (comma-separated) or `all=true`.
+ * Auth reuses LEAD_WITH_OPS_TEST_SECRET.
+ */
+
+type RegistrationDoc = {
+  email?: string
+  firstName?: string
+  thankYouSent?: { id: string; sentAt: string }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const secret = searchParams.get("secret")
+  const dryRun = searchParams.get("dryRun") === "true"
+  const force = searchParams.get("force") === "true"
+  const all = searchParams.get("all") === "true"
+  const emailsParam = searchParams.get("emails")
+
+  if (!secret || secret !== process.env.LEAD_WITH_OPS_TEST_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  // Exactly one selector.
+  const requestedEmails = (emailsParam || "")
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean)
+  if (all === (requestedEmails.length > 0)) {
+    return NextResponse.json(
+      { error: "Provide exactly one selector: `emails` (comma-separated) OR `all=true`." },
+      { status: 400 },
+    )
+  }
+
+  if (!process.env.RESEND_API_KEY) {
+    return NextResponse.json(
+      { error: "RESEND_API_KEY is not configured on the server" },
+      { status: 503 },
+    )
+  }
+
+  // Load registrants for this event.
+  let docs: { id: string; data: RegistrationDoc }[]
+  try {
+    const db = getDigitalCanvasDb()
+    const snapshot = await db.collection(EVENT_COLLECTION).where("event", "==", EVENT_ID).get()
+    docs = snapshot.docs.map((d) => ({ id: d.id, data: d.data() as RegistrationDoc }))
+  } catch (firestoreError) {
+    const message = firestoreError instanceof Error ? firestoreError.message : String(firestoreError)
+    console.error("Firestore error loading registrants:", message)
+    return NextResponse.json({ error: `Could not load registrants: ${message}` }, { status: 503 })
+  }
+
+  const byEmail = new Map(docs.filter((d) => d.data.email).map((d) => [d.data.email!.toLowerCase().trim(), d]))
+
+  // Resolve the target set.
+  const toSend: { id: string; email: string; firstName: string }[] = []
+  const skipped: { recipient: string; reason: string }[] = []
+  const notFound: string[] = []
+
+  const targets = all ? [...byEmail.keys()] : requestedEmails
+  for (const email of targets) {
+    const doc = byEmail.get(email)
+    if (!doc) {
+      notFound.push(email)
+      continue
+    }
+    if (doc.data.thankYouSent && !force) {
+      skipped.push({ recipient: email, reason: `already thanked (${doc.data.thankYouSent.sentAt})` })
+      continue
+    }
+    toSend.push({ id: doc.id, email, firstName: doc.data.firstName?.trim() || "there" })
+  }
+
+  if (dryRun) {
+    return NextResponse.json({
+      dryRun: true,
+      event: EVENT_ID,
+      wouldSend: toSend.map((r) => ({ email: r.email, firstName: r.firstName })),
+      skipped,
+      notFound,
+    })
+  }
+
+  const resend = new Resend(process.env.RESEND_API_KEY)
+  const db = getDigitalCanvasDb()
+
+  const results: { recipient: string; status: "sent" | "failed"; id?: string; error?: string }[] = []
+
+  for (const { id, email, firstName } of toSend) {
+    try {
+      const { data, error } = await sendThankYou(resend, { email, firstName })
+      if (error || !data) {
+        throw new Error(error ? JSON.stringify(error) : "No data returned from Resend")
+      }
+
+      try {
+        await db.collection(EVENT_COLLECTION).doc(id).update({
+          thankYouSent: { id: data.id, sentAt: new Date().toISOString() },
+        })
+      } catch (writeError) {
+        console.error(`Sent thank-you to ${email} but failed to stamp doc ${id}:`, writeError)
+      }
+
+      results.push({ recipient: email, status: "sent", id: data.id })
+    } catch (err) {
+      console.error(`Failed to send thank-you to ${email}:`, err)
+      results.push({ recipient: email, status: "failed", error: String(err) })
+    }
+
+    await sleep(120)
+  }
+
+  const failed = results.filter((r) => r.status === "failed")
+  return NextResponse.json(
+    {
+      event: EVENT_ID,
+      sentCount: results.filter((r) => r.status === "sent").length,
+      failedCount: failed.length,
+      skipped,
+      notFound,
+      results,
+    },
+    { status: failed.length > 0 ? 207 : 200 },
+  )
+}

--- a/lib/emails/lead-with-ops-resend.ts
+++ b/lib/emails/lead-with-ops-resend.ts
@@ -19,6 +19,8 @@ import {
   confirmationEmailText,
   reminderEmailHtml,
   reminderEmailText,
+  thankYouEmailHtml,
+  thankYouEmailText,
   generateLeadWithOpsIcs,
   buildListUnsubscribeHeader,
 } from "@/lib/emails/lead-with-ops"
@@ -35,6 +37,7 @@ export const KBYG_SUBJECT = "Tomorrow: What to know before Lead with Ops. Layer 
 export const CONFIRMATION_SUBJECT =
   "Registration Confirmed | Lead with Ops. Layer in AI. | June 18"
 export const REMINDER_SUBJECT = "Save the date: Lead with Ops. Layer in AI. is June 18"
+export const THANKYOU_SUBJECT = "Thank you for joining us for Lead with Ops. Layer in AI."
 
 /**
  * KBYG delivery cutoff — June 17, 2026 9:00 AM CDT (UTC-5) = 14:00 UTC, the day
@@ -74,6 +77,32 @@ export function kbygIdempotencyKey(email: string): string {
 /** Stable per-recipient idempotency key for the reminder send. */
 export function reminderIdempotencyKey(email: string): string {
   return `reminder-${EVENT_ID}-${email}`
+}
+
+/** Stable per-recipient idempotency key for the post-event thank-you send. */
+export function thankYouIdempotencyKey(email: string): string {
+  return `thankyou-${EVENT_ID}-${email}`
+}
+
+/**
+ * Send the post-event thank-you email to one recipient. No attachment; the
+ * primary CTA links to the feedback survey. Returns Resend's `{ data, error }`.
+ */
+export function sendThankYou(
+  resend: Resend,
+  opts: { email: string; firstName: string },
+) {
+  return resend.emails.send(
+    {
+      from: EMAIL_FROM,
+      to: opts.email,
+      subject: THANKYOU_SUBJECT,
+      html: thankYouEmailHtml({ firstName: opts.firstName, email: opts.email }),
+      text: thankYouEmailText({ firstName: opts.firstName, email: opts.email }),
+      headers: { "List-Unsubscribe": buildListUnsubscribeHeader(opts.email) },
+    },
+    { idempotencyKey: thankYouIdempotencyKey(opts.email) },
+  )
 }
 
 /**

--- a/lib/emails/lead-with-ops.ts
+++ b/lib/emails/lead-with-ops.ts
@@ -772,6 +772,99 @@ export function reminderEmailHtml(opts: KbygOpts): string {
 }
 
 /* ----------------------------------------------------------------------
+ * Template 5 — Post-event thank you.
+ * Sent after the event to thank attendees and drive the post-event survey.
+ * No attachment; primary CTA links to the feedback page.
+ * -------------------------------------------------------------------- */
+
+const FEEDBACK_SURVEY_URL =
+  "https://www.digitalcanvas.community/workshops/lead-with-ops/feedback"
+
+export function thankYouEmailHtml(opts: KbygOpts): string {
+  const body = `
+<!-- Eyebrow + title -->
+<tr>
+  <td style="padding: 32px 32px 0 32px;">
+    <p style="margin: 0 0 14px 0; font-family: ${PIXEL_STACK}; font-size: 11px; letter-spacing: 3px; text-transform: uppercase; color: ${C.emerald}; font-weight: 700;">
+      Thank You
+    </p>
+    <h1 style="margin: 0; font-family: ${PIXEL_STACK}; font-size: 32px; font-weight: 800; line-height: 1.1; text-transform: uppercase; letter-spacing: 0.5px; color: ${C.navy};">
+      Lead with Ops.<br />
+      <span style="color: ${C.gray};">Layer in AI.</span>
+    </h1>
+  </td>
+</tr>
+
+<!-- Greeting + body -->
+<tr>
+  <td style="padding: 28px 32px 0 32px;">
+    <p style="margin: 0 0 18px 0; font-size: 16px; line-height: 1.7; color: ${C.navy};">
+      Hi ${escapeHtml(opts.firstName)},
+    </p>
+    <p style="margin: 0 0 18px 0; font-size: 16px; line-height: 1.7; color: ${C.gray};">
+      Thank you for joining us for <strong style="color: ${C.navy};">Lead with Ops. Layer in AI.</strong> with <strong style="color: ${C.navy};">Adam Carroll</strong>. We appreciate you investing your time to be part of the conversation and contributing to a thoughtful discussion around operations, technology strategy, AI implementation, and business outcomes.
+    </p>
+    <p style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.7; color: ${C.gray};">
+      As we continue to develop future workshops and executive programming through <strong style="color: ${C.navy};">Digital Canvas, 434 Media, DevSA</strong>, and our content partners, your feedback is incredibly valuable.
+    </p>
+  </td>
+</tr>
+
+<!-- Survey CTA -->
+<tr>
+  <td style="padding: 0 32px 28px 32px;">
+    <p style="margin: 0 0 14px 0; font-size: 15px; line-height: 1.7; color: ${C.navy}; font-weight: 600;">
+      We&rsquo;d appreciate your participation in our post-event survey.
+    </p>
+    <table role="presentation" style="border-collapse: collapse;">
+      <tr>
+        <td style="background-color: ${C.coral};">
+          <a href="${FEEDBACK_SURVEY_URL}" target="_blank" style="display: inline-block; padding: 14px 28px; color: ${C.navy}; text-decoration: none; font-family: ${PIXEL_STACK}; font-size: 12px; font-weight: 800; letter-spacing: 1.5px; text-transform: uppercase;">
+            Take the Survey
+          </a>
+        </td>
+      </tr>
+    </table>
+    <p style="margin: 12px 0 0 0; font-size: 12px; color: ${C.gray}; line-height: 1.6;">
+      Or paste this link: <a href="${FEEDBACK_SURVEY_URL}" style="color: ${C.emerald}; text-decoration: none;">${FEEDBACK_SURVEY_URL}</a>
+    </p>
+  </td>
+</tr>
+
+<!-- Closing -->
+<tr>
+  <td style="padding: 0 32px 24px 32px;">
+    <p style="margin: 0; font-size: 15px; line-height: 1.7; color: ${C.navy}; font-weight: 600;">
+      Thank you again for being part of the community. We look forward to seeing you at a future event.
+    </p>
+  </td>
+</tr>
+
+<!-- P.S. -->
+<tr>
+  <td style="padding: 0 32px 24px 32px;">
+    <table role="presentation" style="width: 100%; border-collapse: collapse;">
+      <tr>
+        <td style="padding: 16px 20px; background-color: ${C.offWhite}; border-left: 3px solid ${C.emerald};">
+          <p style="margin: 0; font-size: 14px; line-height: 1.7; color: ${C.gray};">
+            <strong style="color: ${C.navy};">P.S.</strong> If you know another executive, founder, or operator who would benefit from future programming, we&rsquo;d love an introduction.
+          </p>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+`.trim()
+
+  return shell({
+    title: "Thank you for joining us for Lead with Ops. Layer in AI.",
+    previewText: "Thank you for joining the conversation. We'd value your feedback — take our short post-event survey.",
+    body,
+    unsubscribeUrl: buildUnsubscribeUrl(opts.email),
+  })
+}
+
+/* ----------------------------------------------------------------------
  * Plain-text alternatives — sent as the `text` field alongside `html`.
  *
  * Including a text/plain part is a strong deliverability signal — providers
@@ -904,6 +997,33 @@ We'll follow up the day before with a short "know before you go" note — parkin
 If your plans change, just reply to this email so we can offer your seat to another participant.
 
 See you on June 18.
+
+—
+Presented by Digital Canvas · 434 Media
+Questions? VIP@434MEDIA.COM
+
+You're receiving this because you opted in to the 434 Media network.
+Unsubscribe: ${buildUnsubscribeUrl(opts.email)}`
+}
+
+export function thankYouEmailText(opts: KbygOpts): string {
+  return `THANK YOU
+
+Lead with Ops. Layer in AI.
+
+Hi ${opts.firstName},
+
+Thank you for joining us for Lead with Ops. Layer in AI. with Adam Carroll. We appreciate you investing your time to be part of the conversation and contributing to a thoughtful discussion around operations, technology strategy, AI implementation, and business outcomes.
+
+As we continue to develop future workshops and executive programming through Digital Canvas, 434 Media, DevSA, and our content partners, your feedback is incredibly valuable.
+
+We'd appreciate your participation in our post-event survey:
+
+Take the Survey: ${FEEDBACK_SURVEY_URL}
+
+Thank you again for being part of the community. We look forward to seeing you at a future event.
+
+P.S. If you know another executive, founder, or operator who would benefit from future programming, we'd love an introduction.
 
 —
 Presented by Digital Canvas · 434 Media


### PR DESCRIPTION
## Summary
Two Lead with Ops. Layer in AI. email updates.

### Post-event thank-you email
- `thankYouEmailHtml` / `thankYouEmailText` (Adam Carroll design shell) — thanks attendees and drives the post-event survey via a coral **Take the Survey** CTA → `/workshops/lead-with-ops/feedback`, with a P.S. asking for introductions.
- `sendThankYou` helper + `THANKYOU_SUBJECT` (stable idempotency key, no attachment).
- **`app/api/lead-with-ops/send-thankyou`** — personalizes each send from the registration record (first name), targets a specific `emails` list or `all=true`, supports `dryRun`/`force`, and stamps `thankYouSent` per doc so re-runs skip anyone already thanked.
- `send-test`: adds the `thankyou` template for preview.

### KBYG venue change (last-minute room move)
- **"PLEASE NOTE: CHANGE IN MEETING ROOM"** alert banner.
- Venue → **Merchants Ice Building (Building 1), Floor 4 Conf. Room, 1305 E. Houston**; park in **Lot B**; reference the attached map.
- New **Access** row with **210-831-4439** for access issues.
- Updated copy, inbox preview text, and plain-text alternative.

## Verification
- TypeScript clean.
- Thank-you previewed to jesse + marcos; sent personalized to 5 attendees (Sebastian, Vincent, Andy, Abby, Heather) — all delivered.
- KBYG venue update previewed to jesse + marcos.

## Note
The KBYG venue copy references "the attached map," which is still the **VelocityTX campus map** — should be swapped for a Merchants Ice Building / Lot B map before the scheduled June 17 KBYG sends go out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)